### PR TITLE
fix(config): correct XDG config path from .opencode to opencode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azumag/opencode-rate-limit-fallback",
-  "version": "1.70.0",
+  "version": "1.70.1",
   "description": "OpenCode plugin that automatically switches to fallback models when rate limited",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -162,7 +162,9 @@ export function loadConfig(directory: string, worktree?: string, logger?: Logger
 
   const configPaths: string[] = [];
   for (const dir of searchDirs) {
-    configPaths.push(join(dir, ".opencode", "rate-limit-fallback.json"));
+    // XDG config home uses "opencode" (no dot), others use ".opencode"
+    const subdir = dir === xdgConfigHome ? "opencode" : ".opencode";
+    configPaths.push(join(dir, subdir, "rate-limit-fallback.json"));
     configPaths.push(join(dir, "rate-limit-fallback.json"));
   }
 


### PR DESCRIPTION
Fixes #21

The XDG config directory path incorrectly used .opencode instead of opencode. OpenCode stores configs at ~/.config/opencode/ (no dot).

Changes:
- src/utils/config.ts: Use opencode (no dot) for XDG config directory
- Version bumped to 1.70.1

All 606 tests pass.