### PR TITLE
fix: ignore benign Anthropic billing notices during rate-limit fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ OpenCode plugin that automatically switches to fallback models when rate limited
 
 ## Features
 
-- Detects rate limit errors (429, "usage limit", "quota exceeded", "high concurrency", etc.)
+- Detects rate limit errors (429, `rate_limit_error`, "usage limit", "quota exceeded", "high concurrency", etc.)
+- Ignores known benign Anthropic billing notices so they do not trigger false-positive fallbacks
 - Automatically aborts the current request and retries with a fallback model
 - Configurable fallback model list with priority order
 - Three fallback modes: `cycle`, `stop`, and `retry-last`
@@ -122,10 +123,39 @@ Create a configuration file at one of these locations:
   | `fallbackModels` | array | See below | List of fallback models in priority order |
   | `maxSubagentDepth` | number | `10` | Maximum nesting depth for subagent hierarchies |
    | `enableSubagentFallback` | boolean | `true` | Enable/disable fallback for subagent sessions |
-   | `retryPolicy` | object | See below | Retry policy configuration (see below) |
-   | `circuitBreaker` | object | See below | Circuit breaker configuration (see below) |
-   | `configReload` | object | See below | Configuration hot reload settings (see below) |
-   | `dynamicPrioritization` | object | See below | Dynamic prioritization settings (see below) |
+  | `retryPolicy` | object | See below | Retry policy configuration (see below) |
+  | `circuitBreaker` | object | See below | Circuit breaker configuration (see below) |
+  | `errorPatterns` | object | See below | Advanced rate-limit matching overrides and false-positive ignores |
+  | `configReload` | object | See below | Configuration hot reload settings (see below) |
+  | `dynamicPrioritization` | object | See below | Dynamic prioritization settings (see below) |
+
+### Error Pattern Overrides
+
+The plugin now applies a small ignore list before general substring matching so benign provider notices do not trigger a fallback by mistake.
+
+Built-in ignore patterns:
+
+- `not your plan limits`
+- `draw from your extra usage`
+
+Strong signals still win over the ignore list:
+
+- HTTP `429`
+- explicit `rate_limit_error`
+
+Use `errorPatterns.ignorePatterns` to add your own false-positive suppressions:
+
+```json
+{
+  "errorPatterns": {
+    "ignorePatterns": [
+      "not your plan limits",
+      "draw from your extra usage",
+      "internal billing notice"
+    ]
+  }
+}
+```
 
 ### Dynamic Prioritization
 

--- a/__tests__/healthtracker.test.ts
+++ b/__tests__/healthtracker.test.ts
@@ -291,27 +291,20 @@ describe('HealthTracker', () => {
       tracker.recordSuccess('anthropic', 'claude-3-5-sonnet-20250514', 1000);
       tracker.destroy();
 
-      // Wait for async save
-      setTimeout(() => {
-        expect(existsSync(testPersistencePath)).toBe(true);
-      }, 100);
+      expect(existsSync(testPersistencePath)).toBe(true);
     });
 
     it('should load health data from file on initialization', () => {
-      // Create and destroy first tracker
       tracker.recordSuccess('anthropic', 'claude-3-5-sonnet-20250514', 1000);
       tracker.destroy();
 
-      // Wait for save and create new tracker
-      setTimeout(() => {
-        const newTracker = new HealthTracker(testConfig, logger);
-        const health = newTracker.getModelHealth('anthropic', 'claude-3-5-sonnet-20250514');
+      const newTracker = new HealthTracker(testConfig, logger);
+      const health = newTracker.getModelHealth('anthropic', 'claude-3-5-sonnet-20250514');
 
-        expect(health).not.toBeNull();
-        expect(health!.successfulRequests).toBe(1);
+      expect(health).not.toBeNull();
+      expect(health!.successfulRequests).toBe(1);
 
-        newTracker.destroy();
-      }, 100);
+      newTracker.destroy();
     });
 
     it('should handle missing persistence file gracefully', () => {

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -266,6 +266,52 @@ describe('isRateLimitError', () => {
 
     expect(mockClient.session.abort).not.toHaveBeenCalled();
   });
+
+  it('should ignore the benign Anthropic extra usage billing notice', async () => {
+    const error = {
+      data: {
+        message: 'Third-party apps now draw from your extra usage, not your plan limits.',
+      },
+    };
+
+    await pluginInstance.event?.({
+      event: {
+        type: 'session.error',
+        properties: { sessionID: 'test-session', error },
+      },
+    });
+
+    expect(mockClient.session.abort).not.toHaveBeenCalled();
+    expect(mockClient.session.promptAsync).not.toHaveBeenCalled();
+  });
+
+  it('should still fallback on HTTP 429 even when the body contains the ignored billing notice', async () => {
+    const error = {
+      name: 'APIError',
+      data: {
+        statusCode: 429,
+        message: 'Third-party apps now draw from your extra usage, not your plan limits.',
+      },
+    };
+
+    vi.mocked(mockClient.session.messages).mockResolvedValue({
+      data: [
+        {
+          info: { id: 'msg1', role: 'user' },
+          parts: [{ type: 'text', text: 'test message' }],
+        },
+      ],
+    });
+
+    await pluginInstance.event?.({
+      event: {
+        type: 'session.error',
+        properties: { sessionID: 'test-session', error },
+      },
+    });
+
+    expect(mockClient.session.abort).toHaveBeenCalled();
+  });
 });
 
 describe('loadConfig', () => {

--- a/__tests__/patternregistry.test.ts
+++ b/__tests__/patternregistry.test.ts
@@ -78,6 +78,45 @@ describe('ErrorPatternRegistry', () => {
       expect(result).toBe(true);
     });
 
+    it('should ignore the benign Anthropic extra usage billing notice', () => {
+      const error = {
+        message: 'Third-party apps now draw from your extra usage, not your plan limits.',
+      };
+
+      const result = registry.isRateLimitError(error);
+
+      expect(result).toBe(false);
+    });
+
+    it('should not let ignore patterns swallow an explicit HTTP 429 signal', () => {
+      const error = {
+        name: 'APIError',
+        data: {
+          statusCode: 429,
+          message: 'Third-party apps now draw from your extra usage, not your plan limits.',
+        },
+      };
+
+      const result = registry.isRateLimitError(error);
+
+      expect(result).toBe(true);
+    });
+
+    it('should not let ignore patterns swallow an explicit rate_limit_error signal', () => {
+      const error = {
+        data: {
+          responseBody: JSON.stringify({
+            error: 'rate_limit_error',
+            message: 'Third-party apps now draw from your extra usage, not your plan limits.',
+          }),
+        },
+      };
+
+      const result = registry.isRateLimitError(error);
+
+      expect(result).toBe(true);
+    });
+
     it('should detect "too many requests" keyword', () => {
       const error = {
         message: 'Too many requests, please try again later',
@@ -246,6 +285,16 @@ describe('ErrorPatternRegistry', () => {
       expect(pattern).not.toBeNull();
       expect(pattern!.priority).toBe(150);
       expect(pattern!.name).toBe('custom-high-priority');
+    });
+
+    it('should return null when an ignore pattern matches without a strong rate-limit signal', () => {
+      const error = {
+        message: 'Third-party apps now draw from your extra usage, not your plan limits.',
+      };
+
+      const pattern = registry.getMatchedPattern(error);
+
+      expect(pattern).toBeNull();
     });
   });
 

--- a/__tests__/validator.test.ts
+++ b/__tests__/validator.test.ts
@@ -320,6 +320,40 @@ describe('ConfigValidator', () => {
       expect(result.errors).toHaveLength(0);
     });
 
+    it('should validate valid ignore patterns', () => {
+      const config = {
+        fallbackModels: [{ providerID: 'anthropic', modelID: 'claude-3-5-sonnet-20250514' }],
+        cooldownMs: 5000,
+        enabled: true,
+        fallbackMode: 'cycle' as const,
+        errorPatterns: {
+          ignorePatterns: ['not your plan limits', /draw from your extra usage/i],
+        },
+      };
+
+      const result = validator.validate(config);
+
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should reject non-array ignore patterns', () => {
+      const config = {
+        fallbackModels: [{ providerID: 'anthropic', modelID: 'claude-3-5-sonnet-20250514' }],
+        cooldownMs: 5000,
+        enabled: true,
+        fallbackMode: 'cycle' as const,
+        errorPatterns: {
+          ignorePatterns: 'not-an-array',
+        },
+      };
+
+      const result = validator.validate(config, { strict: true });
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors.some(e => e.path === 'errorPatterns.ignorePatterns')).toBe(true);
+    });
+
     // Skip error patterns validation tests - Validator doesn't validate individual pattern elements yet
     // These tests can be re-enabled when pattern validation is implemented
     it.skip('should reject error pattern with empty name (strict mode)', () => {

--- a/index.ts
+++ b/index.ts
@@ -199,7 +199,7 @@ export const RateLimitFallback: Plugin = async ({ client, directory, worktree })
       logger.info("Headless mode — will abort session on rate limit");
 
       // Minimal setup: only error pattern detection + abort
-      const errorPatternRegistry = new ErrorPatternRegistry(logger);
+      const errorPatternRegistry = new ErrorPatternRegistry(logger, config.errorPatterns?.ignorePatterns);
       if (config.errorPatterns?.custom) {
         errorPatternRegistry.registerMany(config.errorPatterns.custom);
       }
@@ -240,14 +240,7 @@ export const RateLimitFallback: Plugin = async ({ client, directory, worktree })
             const props = event.properties;
             const status = props?.status;
             if (status?.type === "retry" && status?.message) {
-              const message = status.message.toLowerCase();
-              const isRateLimitRetry =
-                message.includes("usage limit") ||
-                message.includes("usage exceeded") ||
-                message.includes("rate limit") ||
-                message.includes("high concurrency") ||
-                message.includes("reduce concurrency");
-              if (isRateLimitRetry) {
+              if (errorPatternRegistry.isRateLimitError({ message: status.message })) {
                 await abortSession(props.sessionID, "session.status retry");
               }
             }
@@ -261,7 +254,7 @@ export const RateLimitFallback: Plugin = async ({ client, directory, worktree })
   }
 
   // Initialize error pattern registry
-  const errorPatternRegistry = new ErrorPatternRegistry(logger);
+  const errorPatternRegistry = new ErrorPatternRegistry(logger, config.errorPatterns?.ignorePatterns);
   if (config.errorPatterns?.custom) {
     errorPatternRegistry.registerMany(config.errorPatterns.custom);
   }
@@ -415,15 +408,7 @@ export const RateLimitFallback: Plugin = async ({ client, directory, worktree })
         const status = props?.status;
 
         if (status?.type === "retry" && status?.message) {
-          const message = status.message.toLowerCase();
-          const isRateLimitRetry =
-            message.includes("usage limit") ||
-            message.includes("usage exceeded") ||
-            message.includes("rate limit") ||
-            message.includes("high concurrency") ||
-            message.includes("reduce concurrency");
-
-          if (isRateLimitRetry) {
+          if (errorPatternRegistry.isRateLimitError({ message: status.message })) {
             // Try fallback on any attempt, handleRateLimitFallback will manage state
             await fallbackHandler.handleRateLimitFallback(props.sessionID, "", "");
           }

--- a/src/config/Validator.ts
+++ b/src/config/Validator.ts
@@ -517,6 +517,15 @@ export class ConfigValidator {
             value: config.errorPatterns.custom,
           });
         }
+
+        if (config.errorPatterns.ignorePatterns && !Array.isArray(config.errorPatterns.ignorePatterns)) {
+          errors.push({
+            path: 'errorPatterns.ignorePatterns',
+            message: 'ignorePatterns must be an array',
+            severity: 'error',
+            value: config.errorPatterns.ignorePatterns,
+          });
+        }
       }
     }
 

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -157,6 +157,10 @@ export const DEFAULT_PATTERN_LEARNING_CONFIG = {
  */
 export const DEFAULT_ERROR_PATTERNS_CONFIG = {
   custom: undefined,
+  ignorePatterns: [
+    'not your plan limits',
+    'draw from your extra usage',
+  ],
   enableLearning: false,
   autoApproveThreshold: 0.8,
   maxLearnedPatterns: 20,

--- a/src/errors/PatternRegistry.ts
+++ b/src/errors/PatternRegistry.ts
@@ -3,7 +3,8 @@
  */
 
 import type { ErrorPattern, LearnedPattern, PatternLearningConfig } from '../types/index.js';
-import { Logger } from '../../logger.js';
+import type { Logger } from '../../logger.js';
+import { DEFAULT_ERROR_PATTERNS_CONFIG } from '../config/defaults.js';
 import { PatternLearner } from './PatternLearner.js';
 
 /**
@@ -12,6 +13,7 @@ import { PatternLearner } from './PatternLearner.js';
  */
 export class ErrorPatternRegistry {
   private patterns: ErrorPattern[] = [];
+  private ignorePatterns: (string | RegExp)[] = [];
   private learnedPatterns: LearnedPattern[] = [];
   private patternLearner: PatternLearner | null = null;
   private learningConfig: PatternLearningConfig | null = null;
@@ -19,7 +21,10 @@ export class ErrorPatternRegistry {
   // @ts-ignore - Unused but kept for potential future use
   private _logger: Logger;
 
-  constructor(logger?: Logger) {
+  constructor(
+    logger?: Logger,
+    ignorePatterns: readonly (string | RegExp)[] = [...(DEFAULT_ERROR_PATTERNS_CONFIG.ignorePatterns ?? [])],
+  ) {
     // Initialize logger
     this._logger = logger || {
       debug: () => {},
@@ -29,6 +34,7 @@ export class ErrorPatternRegistry {
     } as unknown as Logger;
 
     this.registerDefaultPatterns();
+    this.registerIgnorePatterns(ignorePatterns);
   }
 
   /**
@@ -49,8 +55,11 @@ export class ErrorPatternRegistry {
         'rate_limit',
         'ratelimit',
         'too many requests',
+        'usage limit',
         'quota exceeded',
         'usage exceeded',
+        'high concurrency',
+        'reduce concurrency',
       ],
       priority: 90,
     });
@@ -122,6 +131,14 @@ export class ErrorPatternRegistry {
     for (const pattern of patterns) {
       this.register(pattern);
     }
+  }
+
+  registerIgnorePatterns(patterns: readonly (string | RegExp)[]): void {
+    this.ignorePatterns = [...patterns];
+  }
+
+  getIgnorePatterns(): (string | RegExp)[] {
+    return [...this.ignorePatterns];
   }
 
   /**
@@ -216,24 +233,15 @@ export class ErrorPatternRegistry {
     // Combine all text sources for matching
     const allText = [responseBody, message, name, statusCode].join(' ').toLowerCase();
 
+    const hasStrongRateLimitSignal = this.hasStrongRateLimitSignal(allText);
+    if (!hasStrongRateLimitSignal && this.matchesIgnorePattern(allText)) {
+      return null;
+    }
+
     // Check each pattern in default patterns first
     for (const pattern of this.patterns) {
       for (const patternStr of pattern.patterns) {
-        let match = false;
-
-        if (typeof patternStr === 'string') {
-          // String matching (case-insensitive)
-          if (allText.includes(patternStr.toLowerCase())) {
-            match = true;
-          }
-        } else if (patternStr instanceof RegExp) {
-          // RegExp matching
-          if (patternStr.test(allText)) {
-            match = true;
-          }
-        }
-
-        if (match) {
+        if (this.matchesPattern(patternStr, allText)) {
           return pattern;
         }
       }
@@ -242,21 +250,7 @@ export class ErrorPatternRegistry {
     // Check learned patterns
     for (const pattern of this.learnedPatterns) {
       for (const patternStr of pattern.patterns) {
-        let match = false;
-
-        if (typeof patternStr === 'string') {
-          // String matching (case-insensitive)
-          if (allText.includes(patternStr.toLowerCase())) {
-            match = true;
-          }
-        } else if (patternStr instanceof RegExp) {
-          // RegExp matching
-          if (patternStr.test(allText)) {
-            match = true;
-          }
-        }
-
-        if (match) {
+        if (this.matchesPattern(patternStr, allText)) {
           return pattern;
         }
       }
@@ -347,5 +341,28 @@ export class ErrorPatternRegistry {
     if (priority >= 70) return 'medium (70-89)';
     if (priority >= 50) return 'low (50-69)';
     return 'very low (<50)';
+  }
+
+  private matchesIgnorePattern(text: string): boolean {
+    for (const pattern of this.ignorePatterns) {
+      if (this.matchesPattern(pattern, text)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private hasStrongRateLimitSignal(text: string): boolean {
+    return this.matchesPattern(/\b429\b/i, text) || this.matchesPattern('rate_limit_error', text);
+  }
+
+  private matchesPattern(pattern: string | RegExp, text: string): boolean {
+    if (typeof pattern === 'string') {
+      return text.includes(pattern.toLowerCase());
+    }
+
+    pattern.lastIndex = 0;
+    return pattern.test(text);
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -202,6 +202,7 @@ export interface ErrorPattern {
  */
 export interface ErrorPatternsConfig {
   custom?: ErrorPattern[];
+  ignorePatterns?: readonly (string | RegExp)[];
   enableLearning?: boolean;
   learnedPatterns?: LearnedPattern[];
   autoApproveThreshold?: number;


### PR DESCRIPTION
## Summary
This hardens rate-limit detection so Anthropic's benign billing notice (for example, "Third-party apps now draw from your extra usage, not your plan limits") no longer triggers a false-positive fallback.

Closes #25

## What changed
- add `errorPatterns.ignorePatterns` to the public config surface
- register built-in ignore patterns for `not your plan limits` and `draw from your extra usage`
- apply the ignore check before general positive matching in `PatternRegistry`
- preserve strong rate-limit signals such as HTTP `429` and explicit `rate_limit_error`
- route `session.status` retry detection through the shared registry logic
- add regression coverage for the benign notice and for genuine 429 behavior
- document the stricter behavior and the new config option in the README

## Verification
- `npm run typecheck`
- `npm run test`
- `npm run build`

## Note
While running the full suite, I also fixed two existing unawaited persistence assertions in `__tests__/healthtracker.test.ts` because Vitest was reporting them as unhandled async errors and blocking a clean green run.