### PR TITLE
fix: harden fallback config and publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,16 +8,27 @@ on:
     branches:
       - main
 
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   check-version:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: >-
+      ${{
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_branch == 'main' &&
+        github.event.workflow_run.head_repository.full_name == github.repository
+      }}
     outputs:
       changed: ${{ steps.check.outputs.changed }}
       version: ${{ steps.check.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 2
       
       - name: Check if version changed
@@ -30,21 +41,32 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: check-version
-    if: ${{ needs.check-version.outputs.changed == 'true' }}
+    if: >-
+      ${{
+        needs.check-version.outputs.changed == 'true' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_branch == 'main' &&
+        github.event.workflow_run.head_repository.full_name == github.repository
+      }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
       
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
       
       - name: Download build artifacts
-        uses: dawidd6/action-download-artifact@v3
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist
           path: dist/
-          run_id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
       
       - run: npm publish --access public --ignore-scripts
         env:

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ Use `errorPatterns.ignorePatterns` to add your own false-positive suppressions:
 }
 ```
 
+The configured array replaces the built-in list. Include the built-in entries when extending it, as shown above. Set it to `[]` to disable ignore matching entirely. Entries must be non-empty strings (or `RegExp` values when configuring the plugin programmatically), and changes are applied by config hot reload.
+
 ### Dynamic Prioritization
 
 The dynamic prioritization feature automatically reorders your fallback models based on their performance metrics, helping you use the most reliable and fastest models first.

--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join, sep } from 'path';
+import { tmpdir } from 'os';
+import { loadConfig, validateConfig } from '../src/utils/config.js';
+import type { PluginConfig } from '../src/types/index.js';
+
+describe('config utilities', () => {
+  let testRoot: string;
+
+  beforeEach(() => {
+    testRoot = mkdtempSync(join(tmpdir(), 'rate-limit-config-test-'));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    rmSync(testRoot, { recursive: true, force: true });
+  });
+
+  it('loads the XDG config when XDG_CONFIG_HOME has a trailing separator', () => {
+    const xdgHome = join(testRoot, 'xdg');
+    const configPath = join(xdgHome, 'opencode', 'rate-limit-fallback.json');
+    mkdirSync(join(xdgHome, 'opencode'), { recursive: true });
+    writeFileSync(configPath, JSON.stringify({ cooldownMs: 12345 }));
+    vi.stubEnv('HOME', join(testRoot, 'home'));
+    vi.stubEnv('XDG_CONFIG_HOME', `${xdgHome}${sep}`);
+
+    const result = loadConfig(join(testRoot, 'project'));
+
+    expect(result.source).toBe(configPath);
+    expect(result.config.cooldownMs).toBe(12345);
+  });
+
+  it('checks the XDG opencode directory when HOME and XDG_CONFIG_HOME resolve to the same path', () => {
+    const sharedHome = join(testRoot, 'shared-home');
+    const configPath = join(sharedHome, 'opencode', 'rate-limit-fallback.json');
+    const homeConfigPath = join(sharedHome, '.opencode', 'rate-limit-fallback.json');
+    mkdirSync(join(sharedHome, 'opencode'), { recursive: true });
+    mkdirSync(join(sharedHome, '.opencode'), { recursive: true });
+    writeFileSync(configPath, JSON.stringify({ cooldownMs: 23456 }));
+    writeFileSync(homeConfigPath, JSON.stringify({ cooldownMs: 34567 }));
+    vi.stubEnv('HOME', sharedHome);
+    vi.stubEnv('XDG_CONFIG_HOME', `${sharedHome}${sep}`);
+
+    const result = loadConfig(join(testRoot, 'project'));
+
+    expect(result.source).toBe(homeConfigPath);
+    expect(result.config.cooldownMs).toBe(34567);
+  });
+
+  it('filters invalid ignore pattern entries before runtime matching', () => {
+    const config = validateConfig({
+      errorPatterns: {
+        ignorePatterns: ['valid notice', null, 123, '   '],
+      },
+    } as unknown as Partial<PluginConfig>);
+
+    expect(config.errorPatterns?.ignorePatterns).toEqual(['valid notice']);
+  });
+
+  it('preserves an empty ignore pattern list', () => {
+    const config = validateConfig({
+      errorPatterns: { ignorePatterns: [] },
+    });
+
+    expect(config.errorPatterns?.ignorePatterns).toEqual([]);
+  });
+
+  it('falls back to built-in ignore patterns when the configured value is null', () => {
+    const config = validateConfig({
+      errorPatterns: { ignorePatterns: null },
+    } as unknown as Partial<PluginConfig>);
+
+    expect(config.errorPatterns?.ignorePatterns).toEqual([
+      'not your plan limits',
+      'draw from your extra usage',
+    ]);
+  });
+});

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { RateLimitFallback } from '../../index';
+import { FallbackHandler } from '../src/fallback/FallbackHandler.js';
 
 // Mock the OpenCode plugin module
 vi.mock('@opencode-ai/plugin', () => ({
@@ -859,6 +860,51 @@ describe('RateLimitFallback Plugin - Event Handling', () => {
     });
 
     expect(mockClient.session.abort).toHaveBeenCalled();
+  });
+
+  it('should not record ignored message.updated notices as model failures', async () => {
+    const handleMessageUpdated = vi.spyOn(FallbackHandler.prototype, 'handleMessageUpdated');
+
+    try {
+      await pluginInstance.event?.({
+        event: {
+          type: 'message.updated',
+          properties: {
+            info: {
+              id: 'real-error',
+              sessionID: 'test-session',
+              providerID: 'anthropic',
+              modelID: 'claude-3-5-sonnet',
+              error: { message: 'Invalid API key' },
+            },
+          },
+        },
+      });
+      expect(handleMessageUpdated).toHaveBeenCalledWith('test-session', 'real-error', true, false);
+      handleMessageUpdated.mockClear();
+
+      await pluginInstance.event?.({
+        event: {
+          type: 'message.updated',
+          properties: {
+            info: {
+              id: 'billing-notice',
+              sessionID: 'test-session',
+              providerID: 'anthropic',
+              modelID: 'claude-3-5-sonnet',
+              error: {
+                message: 'Third-party apps now draw from your extra usage, not your plan limits.',
+              },
+            },
+          },
+        },
+      });
+
+      expect(handleMessageUpdated).not.toHaveBeenCalled();
+      expect(mockClient.session.abort).not.toHaveBeenCalled();
+    } finally {
+      handleMessageUpdated.mockRestore();
+    }
   });
 
   it('should handle session.status events with retry status', async () => {

--- a/__tests__/main/configreloader.test.ts
+++ b/__tests__/main/configreloader.test.ts
@@ -47,6 +47,11 @@ describe('ConfigReloader', () => {
       metricsManager: {
         updateConfig: vi.fn(),
       },
+      errorPatternRegistry: {
+        registerIgnorePatterns: vi.fn(),
+        updateLearnedPatterns: vi.fn(),
+        configurePatternLearning: vi.fn(),
+      },
     };
 
     // Create mock validator
@@ -140,6 +145,66 @@ describe('ConfigReloader', () => {
           duration: 3000,
         },
       });
+    });
+
+    it('should hot reload ignore patterns, including an explicit empty list', async () => {
+      writeFileSync(configPath, JSON.stringify({
+        ...config,
+        errorPatterns: { ignorePatterns: ['custom billing notice'] },
+      }));
+
+      const reloader = new ConfigReloader(
+        config,
+        configPath,
+        mockLogger,
+        mockValidator,
+        mockClient,
+        mockComponents,
+        testDir,
+        undefined,
+        false,
+        0
+      );
+
+      await reloader.reloadConfig();
+      expect(mockComponents.errorPatternRegistry.registerIgnorePatterns)
+        .toHaveBeenLastCalledWith(['custom billing notice']);
+
+      writeFileSync(configPath, JSON.stringify({
+        ...config,
+        errorPatterns: { ignorePatterns: [] },
+      }));
+      await reloader.reloadConfig();
+
+      expect(mockComponents.errorPatternRegistry.registerIgnorePatterns)
+        .toHaveBeenLastCalledWith([]);
+    });
+
+    it('should hot reload pattern learning with default values and the config source', async () => {
+      writeFileSync(configPath, JSON.stringify({
+        ...config,
+        errorPatterns: { enableLearning: true, minErrorFrequency: 7 },
+      }));
+
+      const reloader = new ConfigReloader(
+        config,
+        configPath,
+        mockLogger,
+        mockValidator,
+        mockClient,
+        mockComponents,
+        testDir
+      );
+
+      await reloader.reloadConfig();
+
+      expect(mockComponents.errorPatternRegistry.configurePatternLearning).toHaveBeenCalledWith({
+        enabled: true,
+        autoApproveThreshold: 0.8,
+        maxLearnedPatterns: 20,
+        minErrorFrequency: 7,
+        learningWindowMs: 86400000,
+      }, configPath);
     });
 
     it('should track successful reload metrics', async () => {

--- a/__tests__/patternregistry.test.ts
+++ b/__tests__/patternregistry.test.ts
@@ -86,6 +86,21 @@ describe('ErrorPatternRegistry', () => {
       const result = registry.isRateLimitError(error);
 
       expect(result).toBe(false);
+      expect(registry.classifyError(error)).toBe('ignored');
+    });
+
+    it('should classify unmatched errors separately from ignored notices', () => {
+      expect(registry.classifyError({ message: 'Invalid API key' })).toBe('other');
+    });
+
+    it('should discard invalid ignore patterns defensively', () => {
+      const defensiveRegistry = new ErrorPatternRegistry(
+        logger,
+        ['valid notice', null, 123, ''] as any,
+      );
+
+      expect(defensiveRegistry.getIgnorePatterns()).toEqual(['valid notice']);
+      expect(() => defensiveRegistry.isRateLimitError({ message: 'usage limit' })).not.toThrow();
     });
 
     it('should not let ignore patterns swallow an explicit HTTP 429 signal', () => {
@@ -100,6 +115,7 @@ describe('ErrorPatternRegistry', () => {
       const result = registry.isRateLimitError(error);
 
       expect(result).toBe(true);
+      expect(registry.classifyError(error)).toBe('rate-limit');
     });
 
     it('should not let ignore patterns swallow an explicit rate_limit_error signal', () => {
@@ -498,7 +514,33 @@ describe('ErrorPatternRegistry', () => {
     });
   });
 
-  // Note: Pattern learning functionality has been removed as it was experimental
-  // and not being used in production. Patterns can still be manually registered
-  // via configuration using the register() and registerMany() methods.
+  describe('configurePatternLearning()', () => {
+    const learningConfig = {
+      enabled: false,
+      autoApproveThreshold: 0.8,
+      maxLearnedPatterns: 20,
+      minErrorFrequency: 3,
+      learningWindowMs: 86400000,
+    };
+
+    it('should support enabling, disabling, and re-enabling learning', () => {
+      registry.configurePatternLearning(learningConfig, '/tmp/config.json');
+      expect(registry.getPatternLearner()).toBeNull();
+      expect(registry.isLearningEnabled()).toBe(false);
+
+      registry.configurePatternLearning({ ...learningConfig, enabled: true }, '/tmp/config.json');
+      const learner = registry.getPatternLearner();
+      expect(learner).not.toBeNull();
+      expect(registry.isLearningEnabled()).toBe(true);
+
+      registry.configurePatternLearning({ ...learningConfig, enabled: false });
+      expect(registry.getPatternLearner()).toBe(learner);
+      expect(registry.isLearningEnabled()).toBe(false);
+
+      registry.configurePatternLearning({ ...learningConfig, enabled: true });
+      expect(registry.getPatternLearner()).toBe(learner);
+      expect(registry.isLearningEnabled()).toBe(true);
+    });
+  });
+
 });

--- a/__tests__/validator.test.ts
+++ b/__tests__/validator.test.ts
@@ -354,8 +354,46 @@ describe('ConfigValidator', () => {
       expect(result.errors.some(e => e.path === 'errorPatterns.ignorePatterns')).toBe(true);
     });
 
-    // Skip error patterns validation tests - Validator doesn't validate individual pattern elements yet
-    // These tests can be re-enabled when pattern validation is implemented
+    it('should reject invalid ignore pattern entries', () => {
+      const config = {
+        fallbackModels: [{ providerID: 'anthropic', modelID: 'claude-3-5-sonnet-20250514' }],
+        cooldownMs: 5000,
+        enabled: true,
+        fallbackMode: 'cycle' as const,
+        errorPatterns: {
+          ignorePatterns: ['valid notice', null, 123, ''],
+        },
+      };
+
+      const result = validator.validate(config as any, { strict: true });
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors.map(e => e.path)).toEqual(expect.arrayContaining([
+        'errorPatterns.ignorePatterns[1]',
+        'errorPatterns.ignorePatterns[2]',
+        'errorPatterns.ignorePatterns[3]',
+      ]));
+    });
+
+    it('should reject null ignore patterns', () => {
+      const config = {
+        fallbackModels: [{ providerID: 'anthropic', modelID: 'claude-3-5-sonnet-20250514' }],
+        cooldownMs: 5000,
+        enabled: true,
+        fallbackMode: 'cycle' as const,
+        errorPatterns: {
+          ignorePatterns: null,
+        },
+      };
+
+      const result = validator.validate(config as any, { strict: true });
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors.some(e => e.path === 'errorPatterns.ignorePatterns')).toBe(true);
+    });
+
+    // Skip custom error pattern tests - Validator doesn't validate individual custom entries yet
+    // These tests can be re-enabled when custom pattern validation is implemented
     it.skip('should reject error pattern with empty name (strict mode)', () => {
       const config = {
         fallbackModels: [{ providerID: 'anthropic', modelID: 'claude-3-5-sonnet-20250514' }],

--- a/__tests__/workflow.test.ts
+++ b/__tests__/workflow.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('npm publish workflow', () => {
+  const workflow = readFileSync(
+    join(process.cwd(), '.github', 'workflows', 'npm-publish.yml'),
+    'utf-8',
+  );
+
+  it('allows only successful main pushes from this repository', () => {
+    expect(workflow.match(/github\.event\.workflow_run\.conclusion == 'success'/g)).toHaveLength(2);
+    expect(workflow.match(/github\.event\.workflow_run\.event == 'push'/g)).toHaveLength(2);
+    expect(workflow.match(/github\.event\.workflow_run\.head_branch == 'main'/g)).toHaveLength(2);
+    expect(workflow.match(
+      /github\.event\.workflow_run\.head_repository\.full_name == github\.repository/g,
+    )).toHaveLength(2);
+  });
+
+  it('uses the triggering CI run SHA and artifact in the publish job', () => {
+    expect(workflow.match(/ref: \$\{\{ github\.event\.workflow_run\.head_sha \}\}/g)).toHaveLength(2);
+    expect(workflow).toContain('run-id: ${{ github.event.workflow_run.id }}');
+    expect(workflow).toContain('github-token: ${{ github.token }}');
+    expect(workflow).toContain('repository: ${{ github.repository }}');
+  });
+
+  it('pins every action to an immutable commit and uses the official artifact action', () => {
+    const actionRefs = [...workflow.matchAll(/uses:\s+([^\s#]+)/g)].map((match) => match[1]);
+
+    expect(actionRefs).toHaveLength(4);
+    expect(actionRefs.every((ref) => /@[0-9a-f]{40}$/.test(ref))).toBe(true);
+    expect(actionRefs).toContain(
+      'actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093',
+    );
+    expect(workflow).not.toContain('dawidd6/action-download-artifact');
+  });
+});

--- a/index.ts
+++ b/index.ts
@@ -378,13 +378,16 @@ export const RateLimitFallback: Plugin = async ({ client, directory, worktree })
       // Handle message.updated events
       if (isMessageUpdatedEvent(event)) {
         const info = event.properties.info;
+        const errorClassification = info?.error
+          ? errorPatternRegistry.classifyError(info.error)
+          : null;
 
         // Track model info for all assistant messages (needed to identify current model on session.error)
         if (info?.providerID && info?.modelID && info?.sessionID) {
           fallbackHandler.setSessionModel(info.sessionID, info.providerID, info.modelID);
         }
 
-        if (info?.error && errorPatternRegistry.isRateLimitError(info.error)) {
+        if (info?.error && errorClassification === 'rate-limit') {
           // Learn from this error if pattern learning is enabled
           const patternLearner = errorPatternRegistry.getPatternLearner();
           if (patternLearner) {
@@ -396,7 +399,7 @@ export const RateLimitFallback: Plugin = async ({ client, directory, worktree })
         } else if (info?.status === "completed" && !info?.error && info?.id) {
           // Record fallback success
           fallbackHandler.handleMessageUpdated(info.sessionID, info.id, false, false);
-        } else if (info?.error && !errorPatternRegistry.isRateLimitError(info.error) && info?.id) {
+        } else if (info?.error && errorClassification === 'other' && info?.id) {
           // Record non-rate-limit error
           fallbackHandler.handleMessageUpdated(info.sessionID, info.id, true, false);
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azumag/opencode-rate-limit-fallback",
-  "version": "1.0.11",
+  "version": "1.70.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azumag/opencode-rate-limit-fallback",
-      "version": "1.0.11",
+      "version": "1.70.3",
       "license": "MIT",
       "dependencies": {
         "@opencode-ai/plugin": "latest"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azumag/opencode-rate-limit-fallback",
-  "version": "1.70.2",
+  "version": "1.70.3",
   "description": "OpenCode plugin that automatically switches to fallback models when rate limited",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/config/Validator.ts
+++ b/src/config/Validator.ts
@@ -500,8 +500,8 @@ export class ConfigValidator {
     }
 
     // Validate errorPatterns
-    if (config.errorPatterns) {
-      if (typeof config.errorPatterns !== 'object') {
+    if (config.errorPatterns !== undefined) {
+      if (!config.errorPatterns || typeof config.errorPatterns !== 'object' || Array.isArray(config.errorPatterns)) {
         errors.push({
           path: 'errorPatterns',
           message: 'errorPatterns must be an object',
@@ -518,13 +518,27 @@ export class ConfigValidator {
           });
         }
 
-        if (config.errorPatterns.ignorePatterns && !Array.isArray(config.errorPatterns.ignorePatterns)) {
-          errors.push({
-            path: 'errorPatterns.ignorePatterns',
-            message: 'ignorePatterns must be an array',
-            severity: 'error',
-            value: config.errorPatterns.ignorePatterns,
-          });
+        if (config.errorPatterns.ignorePatterns !== undefined) {
+          if (!Array.isArray(config.errorPatterns.ignorePatterns)) {
+            errors.push({
+              path: 'errorPatterns.ignorePatterns',
+              message: 'ignorePatterns must be an array',
+              severity: 'error',
+              value: config.errorPatterns.ignorePatterns,
+            });
+          } else {
+            config.errorPatterns.ignorePatterns.forEach((pattern, index) => {
+              const isValidString = typeof pattern === 'string' && pattern.trim().length > 0;
+              if (!isValidString && !(pattern instanceof RegExp)) {
+                errors.push({
+                  path: `errorPatterns.ignorePatterns[${index}]`,
+                  message: 'ignore pattern must be a non-empty string or RegExp',
+                  severity: 'error',
+                  value: pattern,
+                });
+              }
+            });
+          }
         }
       }
     }

--- a/src/errors/PatternRegistry.ts
+++ b/src/errors/PatternRegistry.ts
@@ -7,6 +7,8 @@ import type { Logger } from '../../logger.js';
 import { DEFAULT_ERROR_PATTERNS_CONFIG } from '../config/defaults.js';
 import { PatternLearner } from './PatternLearner.js';
 
+export type ErrorClassification = 'rate-limit' | 'ignored' | 'other';
+
 /**
  * Error Pattern Registry class
  * Manages and matches error patterns for rate limit detection
@@ -23,7 +25,7 @@ export class ErrorPatternRegistry {
 
   constructor(
     logger?: Logger,
-    ignorePatterns: readonly (string | RegExp)[] = [...(DEFAULT_ERROR_PATTERNS_CONFIG.ignorePatterns ?? [])],
+    ignorePatterns: readonly (string | RegExp)[] | null = [...(DEFAULT_ERROR_PATTERNS_CONFIG.ignorePatterns ?? [])],
   ) {
     // Initialize logger
     this._logger = logger || {
@@ -133,8 +135,11 @@ export class ErrorPatternRegistry {
     }
   }
 
-  registerIgnorePatterns(patterns: readonly (string | RegExp)[]): void {
-    this.ignorePatterns = [...patterns];
+  registerIgnorePatterns(patterns: readonly (string | RegExp)[] | null | undefined): void {
+    this.ignorePatterns = Array.isArray(patterns)
+      ? patterns.filter((pattern): pattern is string | RegExp =>
+        (typeof pattern === 'string' && pattern.trim().length > 0) || pattern instanceof RegExp)
+      : [];
   }
 
   getIgnorePatterns(): (string | RegExp)[] {
@@ -145,9 +150,24 @@ export class ErrorPatternRegistry {
    * Initialize pattern learning
    */
   initializePatternLearning(config: PatternLearningConfig, configFilePath: string): void {
-    this.learningConfig = config;
-    this.patternLearner = new PatternLearner(config, this._logger);
-    this.patternLearner.setConfigFilePath(configFilePath);
+    this.configurePatternLearning(config, configFilePath);
+  }
+
+  /**
+   * Apply pattern learning settings, creating a learner only when enabled.
+   */
+  configurePatternLearning(config: PatternLearningConfig, configFilePath?: string): void {
+    this.learningConfig = { ...config };
+
+    if (!this.patternLearner && config.enabled) {
+      this.patternLearner = new PatternLearner(config, this._logger);
+    } else if (this.patternLearner) {
+      this.patternLearner.updateConfig(config);
+    }
+
+    if (this.patternLearner && configFilePath) {
+      this.patternLearner.setConfigFilePath(configFilePath);
+    }
   }
 
   /**
@@ -202,7 +222,14 @@ export class ErrorPatternRegistry {
    * Check if an error matches any registered rate limit pattern
    */
   isRateLimitError(error: unknown): boolean {
-    return this.getMatchedPattern(error) !== null;
+    return this.classifyError(error) === 'rate-limit';
+  }
+
+  /**
+   * Classify an error so ignored notices are not counted as model failures.
+   */
+  classifyError(error: unknown): ErrorClassification {
+    return this.analyzeError(error).classification;
   }
 
   /**
@@ -210,8 +237,12 @@ export class ErrorPatternRegistry {
    * Checks default patterns first, then learned patterns
    */
   getMatchedPattern(error: unknown): ErrorPattern | null {
+    return this.analyzeError(error).pattern;
+  }
+
+  private analyzeError(error: unknown): { classification: ErrorClassification; pattern: ErrorPattern | null } {
     if (!error || typeof error !== 'object') {
-      return null;
+      return { classification: 'other', pattern: null };
     }
 
     const err = error as {
@@ -235,14 +266,14 @@ export class ErrorPatternRegistry {
 
     const hasStrongRateLimitSignal = this.hasStrongRateLimitSignal(allText);
     if (!hasStrongRateLimitSignal && this.matchesIgnorePattern(allText)) {
-      return null;
+      return { classification: 'ignored', pattern: null };
     }
 
     // Check each pattern in default patterns first
     for (const pattern of this.patterns) {
       for (const patternStr of pattern.patterns) {
         if (this.matchesPattern(patternStr, allText)) {
-          return pattern;
+          return { classification: 'rate-limit', pattern };
         }
       }
     }
@@ -251,12 +282,12 @@ export class ErrorPatternRegistry {
     for (const pattern of this.learnedPatterns) {
       for (const patternStr of pattern.patterns) {
         if (this.matchesPattern(patternStr, allText)) {
-          return pattern;
+          return { classification: 'rate-limit', pattern };
         }
       }
     }
 
-    return null;
+    return { classification: 'other', pattern: null };
   }
 
   /**

--- a/src/main/ConfigReloader.ts
+++ b/src/main/ConfigReloader.ts
@@ -6,7 +6,9 @@ import type { Logger } from '../../logger.js';
 import type { PluginConfig, OpenCodeClient, ReloadResult, ReloadMetrics } from '../types/index.js';
 import { loadConfig } from '../utils/config.js';
 import { ConfigValidator } from '../config/Validator.js';
+import { DEFAULT_ERROR_PATTERNS_CONFIG, DEFAULT_PATTERN_LEARNING_CONFIG } from '../config/defaults.js';
 import { safeShowToast } from '../utils/helpers.js';
+import type { ErrorPatternRegistry } from '../errors/PatternRegistry.js';
 
 /**
  * Component references for updating on reload
@@ -18,10 +20,8 @@ export interface ComponentRefs {
   metricsManager?: {
     updateConfig: (newConfig: PluginConfig) => void;
   };
-  errorPatternRegistry?: {
-    updateLearnedPatterns: (patterns: any[]) => void;
-    getPatternLearner: () => { updateConfig: (config: any) => void } | null;
-  };
+  errorPatternRegistry?: Pick<ErrorPatternRegistry,
+    'registerIgnorePatterns' | 'updateLearnedPatterns' | 'configurePatternLearning'>;
 }
 
 /**
@@ -135,7 +135,7 @@ export class ConfigReloader {
       }
 
       // Apply the new configuration
-      this.applyConfigChanges(newConfig);
+      this.applyConfigChanges(newConfig, source);
 
       result.success = true;
       this.reloadMetrics.successfulReloads++;
@@ -162,7 +162,7 @@ export class ConfigReloader {
   /**
    * Apply configuration changes to components
    */
-  private applyConfigChanges(newConfig: PluginConfig): void {
+  private applyConfigChanges(newConfig: PluginConfig, configSource: string | null): void {
     const oldConfig = this.config;
 
     // Update internal config reference
@@ -175,23 +175,28 @@ export class ConfigReloader {
       this.components.metricsManager.updateConfig(newConfig);
     }
 
-    // Reload learned patterns if errorPatterns config changed
-    if (this.components.errorPatternRegistry && newConfig.errorPatterns?.learnedPatterns) {
-      this.components.errorPatternRegistry.updateLearnedPatterns(newConfig.errorPatterns.learnedPatterns);
-      this.logger.info(`Reloaded ${newConfig.errorPatterns.learnedPatterns.length} learned patterns`);
+    // Apply all runtime error-pattern settings without requiring a restart.
+    if (this.components.errorPatternRegistry) {
+      const ignorePatterns = newConfig.errorPatterns?.ignorePatterns ?? DEFAULT_ERROR_PATTERNS_CONFIG.ignorePatterns;
+      this.components.errorPatternRegistry.registerIgnorePatterns(ignorePatterns);
+      this.logger.info(`Reloaded ${ignorePatterns.length} ignore patterns`);
 
-      // Update pattern learner config if it exists
-      const patternLearner = this.components.errorPatternRegistry.getPatternLearner();
-      if (patternLearner && newConfig.errorPatterns) {
-        const patternLearningConfig = {
-          enabled: newConfig.errorPatterns.enableLearning ?? false,
-          autoApproveThreshold: newConfig.errorPatterns.autoApproveThreshold ?? 0.8,
-          maxLearnedPatterns: newConfig.errorPatterns.maxLearnedPatterns ?? 20,
-          minErrorFrequency: newConfig.errorPatterns.minErrorFrequency ?? 3,
-          learningWindowMs: newConfig.errorPatterns.learningWindowMs ?? 86400000,
-        };
-        patternLearner.updateConfig(patternLearningConfig);
+      if (newConfig.errorPatterns?.learnedPatterns) {
+        this.components.errorPatternRegistry.updateLearnedPatterns(newConfig.errorPatterns.learnedPatterns);
+        this.logger.info(`Reloaded ${newConfig.errorPatterns.learnedPatterns.length} learned patterns`);
       }
+
+      const patternLearningConfig = {
+        enabled: newConfig.errorPatterns?.enableLearning ?? DEFAULT_PATTERN_LEARNING_CONFIG.enabled,
+        autoApproveThreshold: newConfig.errorPatterns?.autoApproveThreshold ?? DEFAULT_PATTERN_LEARNING_CONFIG.autoApproveThreshold,
+        maxLearnedPatterns: newConfig.errorPatterns?.maxLearnedPatterns ?? DEFAULT_PATTERN_LEARNING_CONFIG.maxLearnedPatterns,
+        minErrorFrequency: newConfig.errorPatterns?.minErrorFrequency ?? DEFAULT_PATTERN_LEARNING_CONFIG.minErrorFrequency,
+        learningWindowMs: newConfig.errorPatterns?.learningWindowMs ?? DEFAULT_PATTERN_LEARNING_CONFIG.learningWindowMs,
+      };
+      this.components.errorPatternRegistry.configurePatternLearning(
+        patternLearningConfig,
+        configSource ?? this.configPath ?? undefined,
+      );
     }
 
     // Log configuration changes
@@ -243,6 +248,10 @@ export class ConfigReloader {
     // Check log
     if (JSON.stringify(oldConfig.log) !== JSON.stringify(newConfig.log)) {
       changes.push('log: updated');
+    }
+
+    if (JSON.stringify(oldConfig.errorPatterns) !== JSON.stringify(newConfig.errorPatterns)) {
+      changes.push('errorPatterns: updated');
     }
 
     // Check enableHealthBasedSelection

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -84,6 +84,10 @@ export interface ConfigLoadResult {
   rawUserConfig?: Partial<PluginConfig>; // Raw user config before merging with defaults (for verbose diff output)
 }
 
+function isValidIgnorePattern(value: unknown): value is string | RegExp {
+  return (typeof value === 'string' && value.trim().length > 0) || value instanceof RegExp;
+}
+
 /**
  * Validate configuration values
  */
@@ -92,6 +96,14 @@ export function validateConfig(config: Partial<PluginConfig>): PluginConfig {
   const headlessOnRateLimit = config.headlessOnRateLimit;
   const resetInterval = config.metrics?.resetInterval;
   const strategy = config.retryPolicy?.strategy;
+  const errorPatterns = config.errorPatterns &&
+    typeof config.errorPatterns === 'object' &&
+    !Array.isArray(config.errorPatterns)
+    ? config.errorPatterns
+    : undefined;
+  const ignorePatterns = Array.isArray(errorPatterns?.ignorePatterns)
+    ? errorPatterns.ignorePatterns.filter(isValidIgnorePattern)
+    : [...(DEFAULT_ERROR_PATTERNS_CONFIG.ignorePatterns ?? [])];
 
   return {
     ...DEFAULT_CONFIG,
@@ -130,14 +142,15 @@ export function validateConfig(config: Partial<PluginConfig>): PluginConfig {
       ...DEFAULT_DYNAMIC_PRIORITIZATION_CONFIG,
       ...config.dynamicPrioritization,
     } : DEFAULT_DYNAMIC_PRIORITIZATION_CONFIG,
-    errorPatterns: config.errorPatterns ? {
+    errorPatterns: errorPatterns ? {
       ...DEFAULT_ERROR_PATTERNS_CONFIG,
-      ...config.errorPatterns,
-      enableLearning: config.errorPatterns.enableLearning ?? DEFAULT_PATTERN_LEARNING_CONFIG.enabled,
-      autoApproveThreshold: config.errorPatterns.autoApproveThreshold ?? DEFAULT_PATTERN_LEARNING_CONFIG.autoApproveThreshold,
-      maxLearnedPatterns: config.errorPatterns.maxLearnedPatterns ?? DEFAULT_PATTERN_LEARNING_CONFIG.maxLearnedPatterns,
-      minErrorFrequency: config.errorPatterns.minErrorFrequency ?? DEFAULT_PATTERN_LEARNING_CONFIG.minErrorFrequency,
-      learningWindowMs: config.errorPatterns.learningWindowMs ?? DEFAULT_PATTERN_LEARNING_CONFIG.learningWindowMs,
+      ...errorPatterns,
+      ignorePatterns,
+      enableLearning: errorPatterns.enableLearning ?? DEFAULT_PATTERN_LEARNING_CONFIG.enabled,
+      autoApproveThreshold: errorPatterns.autoApproveThreshold ?? DEFAULT_PATTERN_LEARNING_CONFIG.autoApproveThreshold,
+      maxLearnedPatterns: errorPatterns.maxLearnedPatterns ?? DEFAULT_PATTERN_LEARNING_CONFIG.maxLearnedPatterns,
+      minErrorFrequency: errorPatterns.minErrorFrequency ?? DEFAULT_PATTERN_LEARNING_CONFIG.minErrorFrequency,
+      learningWindowMs: errorPatterns.learningWindowMs ?? DEFAULT_PATTERN_LEARNING_CONFIG.learningWindowMs,
     } : DEFAULT_ERROR_PATTERNS_CONFIG,
   };
 }
@@ -150,34 +163,35 @@ export function loadConfig(directory: string, worktree?: string, logger?: Logger
   const xdgConfigHome = process.env.XDG_CONFIG_HOME || join(homedir, ".config");
 
   // Build search paths: worktree first, then directory, then home locations
-  const searchDirs: string[] = [];
+  const searchLocations: Array<{ dir: string; subdir: '.opencode' | 'opencode' }> = [];
   if (worktree) {
-    searchDirs.push(resolve(worktree));
+    searchLocations.push({ dir: resolve(worktree), subdir: '.opencode' });
   }
-  if (!worktree || worktree !== directory) {
-    searchDirs.push(resolve(directory));
+  if (!worktree || resolve(worktree) !== resolve(directory)) {
+    searchLocations.push({ dir: resolve(directory), subdir: '.opencode' });
   }
-  searchDirs.push(resolve(homedir));
-  searchDirs.push(resolve(xdgConfigHome));
+  searchLocations.push({ dir: resolve(homedir), subdir: '.opencode' });
+  searchLocations.push({ dir: resolve(xdgConfigHome), subdir: 'opencode' });
+
+  const searchDirs = [...new Set(searchLocations.map(({ dir }) => dir))];
 
   const configPaths: string[] = [];
-  for (const dir of searchDirs) {
-    // XDG config home uses "opencode" (no dot), others use ".opencode"
-    const subdir = dir === xdgConfigHome ? "opencode" : ".opencode";
+  for (const { dir, subdir } of searchLocations) {
     configPaths.push(join(dir, subdir, "rate-limit-fallback.json"));
     configPaths.push(join(dir, "rate-limit-fallback.json"));
   }
+  const uniqueConfigPaths = [...new Set(configPaths)];
 
   // Log search paths for debugging
   if (logger) {
-    logger.debug(`Searching for config file in ${configPaths.length} locations`);
-    for (const configPath of configPaths) {
+    logger.debug(`Searching for config file in ${uniqueConfigPaths.length} locations`);
+    for (const configPath of uniqueConfigPaths) {
       const exists = existsSync(configPath);
       logger.debug(`  ${exists ? "✓" : "✗"} ${configPath}`);
     }
   }
 
-  for (const configPath of configPaths) {
+  for (const configPath of uniqueConfigPaths) {
     if (existsSync(configPath)) {
       // Validate path safety before reading
       if (!validatePathSafety(configPath, searchDirs)) {
@@ -209,14 +223,14 @@ export function loadConfig(directory: string, worktree?: string, logger?: Logger
 
   if (logger) {
     // Log that no config file was found
-    logger.info(`No config file found in any of the ${configPaths.length} search paths. Using default configuration.`);
+    logger.info(`No config file found in any of the ${uniqueConfigPaths.length} search paths. Using default configuration.`);
 
     // Show a warning if default fallback models is empty (which is now the case)
     if (DEFAULT_CONFIG.fallbackModels.length === 0) {
       logger.warn('No fallback models configured. The plugin will not be able to fallback when rate limited.');
       logger.warn('Please create a config file with your fallback models.');
       logger.warn('Config file locations (in order of priority):');
-      for (const configPath of configPaths) {
+      for (const configPath of uniqueConfigPaths) {
         logger.warn(`  - ${configPath}`);
       }
       logger.warn('Example config:');


### PR DESCRIPTION
## Summary

- normalize XDG config lookup and preserve the intended HOME/XDG priority
- classify ignored provider notices separately so they do not count as model failures
- validate and hot reload ignore patterns and pattern-learning state safely
- restrict npm publishing to successful same-repository main pushes, pin the triggering SHA/artifact, and pin every action to an immutable commit
- document ignore-pattern replacement semantics and bump the package to 1.70.3

## Root cause

The two merged fixes covered their direct cases, but adjacent paths still treated ignored notices as ordinary failures, mishandled some XDG path edge cases, and accepted unsafe runtime config values. The workflow_run publisher also trusted broader trigger and action surfaces than intended.

## Verification

- npm test: 630 passed, 15 skipped
- npm run typecheck
- npm run build
- npm pack --dry-run --ignore-scripts
- Ruby YAML parse for npm-publish.yml
- git diff --check
- independent Sol review: APPROVED, no findings

Actual cross-run artifact retrieval and npm publishing are only exercised after this reaches main.