### PR TITLE
ci: publish npm package with OIDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,18 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       
       - run: npm ci
@@ -29,7 +32,7 @@ jobs:
         run: npm run build
       
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: dist/

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -26,7 +26,7 @@ jobs:
       changed: ${{ steps.check.outputs.changed }}
       version: ${{ steps.check.outputs.version }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 2
@@ -41,6 +41,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: check-version
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
     if: >-
       ${{
         needs.check-version.outputs.changed == 'true' &&
@@ -50,17 +54,21 @@ jobs:
         github.event.workflow_run.head_repository.full_name == github.repository
       }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
       
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
+      - name: Install npm with trusted publishing support
+        run: npm install --global npm@11.19.0 --ignore-scripts
       
       - name: Download build artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist/
@@ -69,5 +77,3 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
       
       - run: npm publish --access public --ignore-scripts
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/__tests__/workflow.test.ts
+++ b/__tests__/workflow.test.ts
@@ -7,6 +7,10 @@ describe('npm publish workflow', () => {
     join(process.cwd(), '.github', 'workflows', 'npm-publish.yml'),
     'utf-8',
   );
+  const ciWorkflow = readFileSync(
+    join(process.cwd(), '.github', 'workflows', 'ci.yml'),
+    'utf-8',
+  );
 
   it('allows only successful main pushes from this repository', () => {
     expect(workflow.match(/github\.event\.workflow_run\.conclusion == 'success'/g)).toHaveLength(2);
@@ -30,8 +34,35 @@ describe('npm publish workflow', () => {
     expect(actionRefs).toHaveLength(4);
     expect(actionRefs.every((ref) => /@[0-9a-f]{40}$/.test(ref))).toBe(true);
     expect(actionRefs).toContain(
-      'actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093',
+      'actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c',
     );
     expect(workflow).not.toContain('dawidd6/action-download-artifact');
+  });
+
+  it('publishes with OIDC instead of a long-lived npm token', () => {
+    const checkVersionJob = workflow.slice(
+      workflow.indexOf('  check-version:'),
+      workflow.indexOf('  publish:'),
+    );
+    const publishJob = workflow.slice(workflow.indexOf('  publish:'));
+
+    expect(workflow).toContain('id-token: write');
+    expect(checkVersionJob).not.toContain('id-token: write');
+    expect(publishJob).toContain('id-token: write');
+    expect(workflow).toContain("node-version: '24'");
+    expect(workflow).toContain('npm install --global npm@11.19.0 --ignore-scripts');
+    expect(workflow).not.toContain('NODE_AUTH_TOKEN');
+    expect(workflow).not.toContain('secrets.NPM_TOKEN');
+  });
+
+  it('uses Node 24 and immutable action commits in CI', () => {
+    const actionRefs = [...ciWorkflow.matchAll(/uses:\s+([^\s#]+)/g)].map((match) => match[1]);
+
+    expect(ciWorkflow).toContain("node-version: '24'");
+    expect(actionRefs).toHaveLength(3);
+    expect(actionRefs.every((ref) => /@[0-9a-f]{40}$/.test(ref))).toBe(true);
+    expect(actionRefs).toContain(
+      'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a',
+    );
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azumag/opencode-rate-limit-fallback",
-  "version": "1.70.3",
+  "version": "1.70.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azumag/opencode-rate-limit-fallback",
-      "version": "1.70.3",
+      "version": "1.70.4",
       "license": "MIT",
       "dependencies": {
         "@opencode-ai/plugin": "latest"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azumag/opencode-rate-limit-fallback",
-  "version": "1.70.3",
+  "version": "1.70.4",
   "description": "OpenCode plugin that automatically switches to fallback models when rate limited",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- publish to npm through the configured Trusted Publisher instead of NPM_TOKEN
- grant id-token: write only to the guarded publish job
- move CI and publishing actions to current Node 24-based releases pinned by commit SHA
- install a fixed npm 11 release with Trusted Publishing support
- bump the package to 1.70.4 to exercise the new release path

## Root cause

The previous automation token reached npm publish but the registry rejected writes with E404. GitHub Actions also reported Node.js 20 deprecation warnings for the v4 action runtimes.

The npm package is now configured with a GitHub Actions Trusted Publisher for azumag/opencode-rate-limit-fallback and npm-publish.yml.

## Verification

- npm test: 632 passed, 15 skipped
- npm run typecheck
- npm run build
- npm pack --dry-run --ignore-scripts
- YAML parse for both workflows
- git diff --check
- independent Sol review: APPROVED, no findings

The OIDC exchange and npm publish will be validated by the main workflow after merge.