### PR TITLE
fix: route plugin diagnostics to app log

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,10 @@ When OpenCode uses subagents (e.g., for complex tasks requiring specialized agen
 | `maxSubagentDepth` | number | `10` | Maximum nesting depth for subagent hierarchies |
 | `enableSubagentFallback` | boolean | `true` | Enable/disable fallback for subagent sessions |
 
+## Logging
+
+Plugin diagnostics are sent through [OpenCode's structured application log API](https://opencode.ai/docs/plugins/#logging). The plugin does not write diagnostics with `console.*`, so enabling `info` logging does not inject messages into the TUI console overlay.
+
 ## Metrics
 
  The plugin includes a metrics collection feature that tracks:
@@ -646,7 +650,7 @@ Metrics can be configured via the `metrics` section in your config file:
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `enabled` | boolean | `false` | Enable/disable metrics collection |
-| `output.console` | boolean | `true` | Print metrics to console |
+| `output.console` | boolean | `true` | Send metrics reports to the OpenCode application log |
 | `output.file` | string | `undefined` | Path to save metrics file |
 | `output.format` | string | `"pretty"` | Output format: `"pretty"`, `"json"`, or `"csv"` |
 | `resetInterval` | string | `"daily"` | Reset interval: `"hourly"`, `"daily"`, or `"weekly"` |

--- a/__tests__/headless.test.ts
+++ b/__tests__/headless.test.ts
@@ -41,6 +41,9 @@ const mockDefaultConfig = () => {
 
 // Helper to create mock client WITHOUT TUI (simulating headless mode)
 const createHeadlessClient = () => ({
+    app: {
+        log: vi.fn().mockResolvedValue(undefined),
+    },
     session: {
         abort: vi.fn().mockResolvedValue(undefined),
         messages: vi.fn(),
@@ -52,6 +55,9 @@ const createHeadlessClient = () => ({
 
 // Helper to create mock client WITH TUI (for config loading tests)
 const createTuiClient = () => ({
+    app: {
+        log: vi.fn().mockResolvedValue(undefined),
+    },
     session: {
         abort: vi.fn().mockResolvedValue(undefined),
         messages: vi.fn(),
@@ -65,6 +71,9 @@ const createTuiClient = () => ({
 
 // Helper to create mock client WITH TUI that throws errors
 const createFailingTuiClient = () => ({
+    app: {
+        log: vi.fn().mockResolvedValue(undefined),
+    },
     session: {
         abort: vi.fn().mockResolvedValue(undefined),
         messages: vi.fn(),
@@ -120,9 +129,15 @@ describe('Headless Mode (No TUI)', () => {
     });
 
     it('should log that headless mode disables fallback', async () => {
-        // Logger uses console.log for info level messages
-        const allLogCalls = consoleLogSpy.mock.calls.map(c => String(c[0]));
+        const allLogCalls = mockClient.app.log.mock.calls.map((call: any[]) => String(call[0]?.body?.message));
         expect(allLogCalls.some(msg => msg.includes('Headless mode detected'))).toBe(true);
+    });
+
+    it('should not write headless diagnostics to console', () => {
+        expect(consoleLogSpy).not.toHaveBeenCalled();
+        expect(consoleWarnSpy).not.toHaveBeenCalled();
+        expect(consoleErrorSpy).not.toHaveBeenCalled();
+        expect(consoleInfoSpy).not.toHaveBeenCalled();
     });
 });
 
@@ -303,7 +318,7 @@ describe('Headless Mode with headlessOnRateLimit: "abort"', () => {
             },
         });
 
-        const allLogCalls = consoleLogSpy.mock.calls.map(c => String(c[0]));
+        const allLogCalls = mockClient.app.log.mock.calls.map((call: any[]) => String(call[0]?.body?.message));
         expect(allLogCalls.some(msg =>
             msg.includes('aborting session') && msg.includes('headless-session-8')
         )).toBe(true);
@@ -492,8 +507,14 @@ describe('TUI Error Handling (Toast Fails)', () => {
         expect(mockClient.session.abort).toHaveBeenCalled();
         // Verify prompt called (fallback happened)
         expect(mockClient.session.promptAsync).toHaveBeenCalled();
-        // Verify logs were printed instead of toast
-        expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('[RateLimitFallback] Rate Limit Detected'));
+        // Verify the failed toast was routed to OpenCode's application log
+        expect(mockClient.app.log).toHaveBeenCalledWith(expect.objectContaining({
+            body: expect.objectContaining({
+                level: 'warn',
+                message: expect.stringContaining('Rate Limit Detected'),
+            }),
+        }));
+        expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
 
     it('should handle missing toast.body when TUI showToast fails', async () => {
@@ -509,7 +530,8 @@ describe('TUI Error Handling (Toast Fails)', () => {
             },
         })).resolves.not.toThrow();
 
-        expect(consoleWarnSpy).toHaveBeenCalled();
+        expect(mockClient.app.log).toHaveBeenCalled();
+        expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
 
     it('should handle missing toast.body.title when TUI showToast fails', async () => {
@@ -523,7 +545,8 @@ describe('TUI Error Handling (Toast Fails)', () => {
             },
         })).resolves.not.toThrow();
 
-        expect(consoleWarnSpy).toHaveBeenCalled();
+        expect(mockClient.app.log).toHaveBeenCalled();
+        expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
 
     it('should handle missing toast.body.message when TUI showToast fails', async () => {
@@ -537,7 +560,8 @@ describe('TUI Error Handling (Toast Fails)', () => {
             },
         })).resolves.not.toThrow();
 
-        expect(consoleWarnSpy).toHaveBeenCalled();
+        expect(mockClient.app.log).toHaveBeenCalled();
+        expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
 
     it('should handle missing toast.body.variant when TUI showToast fails', async () => {
@@ -551,6 +575,7 @@ describe('TUI Error Handling (Toast Fails)', () => {
             },
         })).resolves.not.toThrow();
 
-        expect(consoleWarnSpy).toHaveBeenCalled();
+        expect(mockClient.app.log).toHaveBeenCalled();
+        expect(consoleWarnSpy).not.toHaveBeenCalled();
     });
 });

--- a/__tests__/helpers.test.ts
+++ b/__tests__/helpers.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createLogger, type LogEntry, type LogSink } from '../logger';
+import type { OpenCodeClient } from '../src/types/index';
+import { safeShowToast } from '../src/utils/helpers';
+
+const createClient = (showToast?: ReturnType<typeof vi.fn>): OpenCodeClient => ({
+  session: {
+    abort: vi.fn().mockResolvedValue(undefined),
+    messages: vi.fn().mockResolvedValue({ data: [] }),
+    prompt: vi.fn().mockResolvedValue(undefined),
+    promptAsync: vi.fn().mockResolvedValue(undefined),
+  },
+  ...(showToast ? { tui: { showToast } } : {}),
+});
+
+describe('safeShowToast', () => {
+  let sink: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    sink = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('records a success toast when TUI is unavailable even at warn level', async () => {
+    const logger = createLogger({ level: 'warn' }, 'ToastTest', sink as LogSink);
+
+    await safeShowToast(createClient(), {
+      body: {
+        title: 'Fallback Queued',
+        message: 'Using fallback-model',
+        variant: 'success',
+      },
+    }, logger);
+
+    expect(sink).toHaveBeenCalledTimes(1);
+    expect(sink.mock.calls[0][0] as LogEntry).toMatchObject({
+      level: 'info',
+      message: 'Toast unavailable: Fallback Queued: Using fallback-model',
+      meta: { toastVariant: 'success' },
+    });
+  });
+
+  it('records an info toast when TUI rejects even at warn level', async () => {
+    const showToast = vi.fn().mockRejectedValue(new Error('TUI failed'));
+    const logger = createLogger({ level: 'warn' }, 'ToastTest', sink as LogSink);
+
+    await safeShowToast(createClient(showToast), {
+      body: {
+        title: 'Retrying',
+        message: 'Using fallback-model',
+        variant: 'info',
+      },
+    }, logger);
+
+    expect(showToast).toHaveBeenCalledTimes(1);
+    expect(sink).toHaveBeenCalledTimes(1);
+    expect(sink.mock.calls[0][0] as LogEntry).toMatchObject({
+      level: 'info',
+      message: 'Toast unavailable: Retrying: Using fallback-model',
+      meta: { toastVariant: 'info', error: 'TUI failed' },
+    });
+  });
+
+  it('stays silent without a logger and never falls back to console', async () => {
+    const consoleSpies = [
+      vi.spyOn(console, 'log').mockImplementation(() => undefined),
+      vi.spyOn(console, 'warn').mockImplementation(() => undefined),
+      vi.spyOn(console, 'error').mockImplementation(() => undefined),
+    ];
+
+    await expect(safeShowToast(createClient(), {
+      body: {
+        title: 'Notice',
+        message: 'No logger',
+        variant: 'warning',
+      },
+    })).resolves.toBeUndefined();
+
+    for (const consoleSpy of consoleSpies) {
+      expect(consoleSpy).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -44,6 +44,9 @@ const mockDefaultConfig = () => {
 
 // Helper to create mock client
 const createMockClient = () => ({
+  app: {
+    log: vi.fn().mockResolvedValue(undefined),
+  },
   session: {
     abort: vi.fn().mockResolvedValue(undefined),
     messages: vi.fn(),
@@ -1966,6 +1969,79 @@ describe('Cleanup Functionality', () => {
       pluginInstance.cleanup();
       pluginInstance.cleanup();
     }).not.toThrow();
+  });
+});
+
+describe('Structured application logging', () => {
+  let mockClient: ReturnType<typeof createMockClient>;
+  let pluginInstance: any;
+  let consoleSpies: Array<ReturnType<typeof vi.spyOn>>;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+      fallbackModels: [
+        { providerID: 'anthropic', modelID: 'claude-3-5-sonnet-20250514' },
+      ],
+      enabled: true,
+      log: {
+        level: 'info',
+        format: 'simple',
+        enableTimestamp: false,
+      },
+    }));
+    consoleSpies = [
+      vi.spyOn(console, 'log').mockImplementation(() => undefined),
+      vi.spyOn(console, 'warn').mockImplementation(() => undefined),
+      vi.spyOn(console, 'error').mockImplementation(() => undefined),
+      vi.spyOn(console, 'debug').mockImplementation(() => undefined),
+    ];
+    mockClient = createMockClient();
+    pluginInstance = await RateLimitFallback({
+      client: mockClient as any,
+      directory: '/test',
+      project: {} as any,
+      worktree: '/test',
+      serverUrl: new URL('http://test.com'),
+      $: {} as any,
+    });
+  });
+
+  afterEach(() => {
+    pluginInstance?.cleanup?.();
+    vi.restoreAllMocks();
+  });
+
+  it('routes info diagnostics to client.app.log without touching console', () => {
+    expect(mockClient.app.log).toHaveBeenCalledWith(expect.objectContaining({
+      body: expect.objectContaining({
+        service: 'opencode-rate-limit-fallback',
+        level: 'info',
+        message: expect.stringContaining('Config loaded from'),
+        extra: expect.objectContaining({ component: 'RateLimitFallback' }),
+      }),
+    }));
+
+    for (const consoleSpy of consoleSpies) {
+      expect(consoleSpy).not.toHaveBeenCalled();
+    }
+  });
+
+  it('does not serialize unrelated event bodies into diagnostics', async () => {
+    mockClient.app.log.mockClear();
+
+    await pluginInstance.event?.({
+      event: {
+        type: 'custom.event',
+        properties: {
+          message: 'Free usage exceeded',
+          secret: 'must-not-be-logged',
+        },
+      },
+    });
+
+    expect(mockClient.app.log).not.toHaveBeenCalled();
   });
 });
 

--- a/__tests__/logger.test.ts
+++ b/__tests__/logger.test.ts
@@ -1,514 +1,224 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { Logger, createLogger, type LogLevel, type LogConfig } from '../logger';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  Logger,
+  createLogger,
+  type LogConfig,
+  type LogEntry,
+  type LogLevel,
+  type LogSink,
+} from '../logger';
 
 describe('Logger', () => {
-  // Save and restore console methods
-  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
-  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
-  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
-  let consoleDebugSpy: ReturnType<typeof vi.spyOn>;
+  let sink: ReturnType<typeof vi.fn>;
+
+  const createTestLogger = (
+    config: Partial<LogConfig> = {},
+    component = 'TestComponent',
+  ) => new Logger(config, component, sink as LogSink);
+
+  const entries = (): LogEntry[] => sink.mock.calls.map(([entry]) => entry as LogEntry);
 
   beforeEach(() => {
-    // Spy on console methods
-    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    consoleDebugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
-
-    // Clear environment variables
+    sink = vi.fn();
     delete process.env.RATE_LIMIT_FALLBACK_LOG_LEVEL;
     delete process.env.DEBUG;
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    delete process.env.RATE_LIMIT_FALLBACK_LOG_LEVEL;
+    delete process.env.DEBUG;
   });
 
-  describe('Log Level Priority', () => {
-    it('should output error logs when level is warn', () => {
-      const logger = new Logger({ level: 'warn' }, 'TestComponent');
-      logger.error('Error message');
+  describe('level filtering', () => {
+    it('emits info and higher levels through the sink', () => {
+      const logger = createTestLogger({ level: 'info' });
 
-      expect(consoleErrorSpy).toHaveBeenCalled();
-      expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('[ERROR]'));
+      logger.debug('debug');
+      logger.info('info');
+      logger.warn('warn');
+      logger.error('error');
+
+      expect(entries().map(({ level }) => level)).toEqual(['info', 'warn', 'error']);
     });
 
-    it('should output warn logs when level is warn', () => {
-      const logger = new Logger({ level: 'warn' }, 'TestComponent');
-      logger.warn('Warning message');
+    it('emits only errors when configured for error', () => {
+      const logger = createTestLogger({ level: 'error' });
 
-      expect(consoleWarnSpy).toHaveBeenCalled();
-      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('[WARN]'));
+      logger.debug('debug');
+      logger.info('info');
+      logger.warn('warn');
+      logger.error('error');
+
+      expect(entries().map(({ level }) => level)).toEqual(['error']);
     });
 
-    it('should NOT output info logs when level is warn', () => {
-      const logger = new Logger({ level: 'warn' }, 'TestComponent');
-      logger.info('Info message');
+    it('does not emit at the silent level', () => {
+      const logger = createTestLogger({ level: 'silent' });
 
-      expect(consoleLogSpy).not.toHaveBeenCalled();
+      logger.debug('debug');
+      logger.info('info');
+      logger.warn('warn');
+      logger.error('error');
+
+      expect(sink).not.toHaveBeenCalled();
     });
 
-    it('should NOT output debug logs when level is warn', () => {
-      const logger = new Logger({ level: 'warn' }, 'TestComponent');
-      logger.debug('Debug message');
+    it('supports explicitly requested output at the silent level', () => {
+      const logger = createTestLogger({ level: 'silent' });
 
-      expect(consoleDebugSpy).not.toHaveBeenCalled();
+      logger.emitRaw('info', 'explicit output');
+
+      expect(entries().map(({ level }) => level)).toEqual(['info']);
+      expect(entries()[0].message).toBe('explicit output');
     });
 
-    it('should output all logs when level is debug with DEBUG flag', () => {
+    it('requires DEBUG for debug output', () => {
+      const logger = createTestLogger({ level: 'debug' });
+
+      logger.debug('hidden');
+      expect(sink).not.toHaveBeenCalled();
+
       process.env.DEBUG = '1';
-      const logger = new Logger({ level: 'debug' }, 'TestComponent');
-
-      logger.debug('Debug message');
-      logger.info('Info message');
-      logger.warn('Warning message');
-      logger.error('Error message');
-
-      expect(consoleDebugSpy).toHaveBeenCalled();
-      expect(consoleLogSpy).toHaveBeenCalled();
-      expect(consoleWarnSpy).toHaveBeenCalled();
-      expect(consoleErrorSpy).toHaveBeenCalled();
+      logger.debug('visible');
+      expect(entries().map(({ level }) => level)).toEqual(['debug']);
     });
 
-    it('should only output error logs when level is error', () => {
-      const logger = new Logger({ level: 'error' }, 'TestComponent');
-
-      logger.debug('Debug message');
-      logger.info('Info message');
-      logger.warn('Warning message');
-      logger.error('Error message');
-
-      expect(consoleDebugSpy).not.toHaveBeenCalled();
-      expect(consoleLogSpy).not.toHaveBeenCalled();
-      expect(consoleWarnSpy).not.toHaveBeenCalled();
-      expect(consoleErrorSpy).toHaveBeenCalled();
-    });
-
-    it('should output NO logs when level is silent', () => {
-      const logger = new Logger({ level: 'silent' }, 'TestComponent');
-
-      logger.debug('Debug message');
-      logger.info('Info message');
-      logger.warn('Warning message');
-      logger.error('Error message');
-
-      expect(consoleDebugSpy).not.toHaveBeenCalled();
-      expect(consoleLogSpy).not.toHaveBeenCalled();
-      expect(consoleWarnSpy).not.toHaveBeenCalled();
-      expect(consoleErrorSpy).not.toHaveBeenCalled();
-    });
-
-    it('should output info+ logs when level is info', () => {
-      const logger = new Logger({ level: 'info' }, 'TestComponent');
-
-      logger.debug('Debug message');
-      logger.info('Info message');
-      logger.warn('Warning message');
-      logger.error('Error message');
-
-      expect(consoleDebugSpy).not.toHaveBeenCalled();
-      expect(consoleLogSpy).toHaveBeenCalled();
-      expect(consoleWarnSpy).toHaveBeenCalled();
-      expect(consoleErrorSpy).toHaveBeenCalled();
-    });
-  });
-
-  describe('Format Options', () => {
-    it('should use simple format by default', () => {
-      const logger = new Logger({ level: 'info', format: 'simple' }, 'TestComponent');
-      logger.info('Test message');
-
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringMatching(/^\[.*?\] \[INFO\] \[TestComponent\] Test message$/)
-      );
-    });
-
-    it('should include timestamp in simple format when enabled', () => {
-      const logger = new Logger({ level: 'info', format: 'simple', enableTimestamp: true }, 'TestComponent');
-      logger.info('Test message');
-
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringMatching(/^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\] \[INFO\] \[TestComponent\] Test message$/)
-      );
-    });
-
-    it('should not include timestamp in simple format when disabled', () => {
-      const logger = new Logger({ level: 'info', format: 'simple', enableTimestamp: false }, 'TestComponent');
-      logger.info('Test message');
-
-      const output = consoleLogSpy.mock.calls[0][0] as string;
-      // Should start with [INFO] directly, not [timestamp] [INFO]
-      expect(output).toMatch(/^\[INFO\] \[TestComponent\] Test message$/);
-    });
-
-    it('should use JSON format when specified', () => {
-      const logger = new Logger({ level: 'info', format: 'json' }, 'TestComponent');
-      logger.info('Test message');
-
-      const output = consoleLogSpy.mock.calls[0][0] as string;
-      const parsed = JSON.parse(output);
-
-      expect(parsed).toHaveProperty('level', 'info');
-      expect(parsed).toHaveProperty('component', 'TestComponent');
-      expect(parsed).toHaveProperty('message', 'Test message');
-      expect(parsed).toHaveProperty('timestamp');
-    });
-
-    it('should include metadata in JSON format', () => {
-      const logger = new Logger({ level: 'info', format: 'json' }, 'TestComponent');
-      logger.info('Test message', { requestId: '123', userId: 'user1' });
-
-      const output = consoleLogSpy.mock.calls[0][0] as string;
-      const parsed = JSON.parse(output);
-
-      expect(parsed).toHaveProperty('level', 'info');
-      expect(parsed).toHaveProperty('component', 'TestComponent');
-      expect(parsed).toHaveProperty('message', 'Test message');
-      expect(parsed).toHaveProperty('requestId', '123');
-      expect(parsed).toHaveProperty('userId', 'user1');
-    });
-
-    it('should include timestamp in JSON format when enabled', () => {
-      const logger = new Logger({ level: 'info', format: 'json', enableTimestamp: true }, 'TestComponent');
-      logger.info('Test message');
-
-      const output = consoleLogSpy.mock.calls[0][0] as string;
-      const parsed = JSON.parse(output);
-
-      expect(parsed).toHaveProperty('timestamp');
-      expect(parsed.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
-    });
-
-    it('should not include timestamp in JSON format when disabled', () => {
-      const logger = new Logger({ level: 'info', format: 'json', enableTimestamp: false }, 'TestComponent');
-      logger.info('Test message');
-
-      const output = consoleLogSpy.mock.calls[0][0] as string;
-      const parsed = JSON.parse(output);
-
-      expect(parsed).not.toHaveProperty('timestamp');
-    });
-  });
-
-  describe('Environment Variable Override', () => {
-    it('should override log level with RATE_LIMIT_FALLBACK_LOG_LEVEL', () => {
-      process.env.RATE_LIMIT_FALLBACK_LOG_LEVEL = 'debug';
-      process.env.DEBUG = '1';
-
-      const logger = new Logger({ level: 'error' }, 'TestComponent');
-
-      logger.debug('Debug message');
-      expect(consoleDebugSpy).toHaveBeenCalled();
-
-      logger.info('Info message');
-      expect(consoleLogSpy).toHaveBeenCalled();
-    });
-
-    it('should override to info level with RATE_LIMIT_FALLBACK_LOG_LEVEL', () => {
+    it('applies a valid environment override', () => {
       process.env.RATE_LIMIT_FALLBACK_LOG_LEVEL = 'info';
+      const logger = createTestLogger({ level: 'error' });
 
-      const logger = new Logger({ level: 'error' }, 'TestComponent');
+      logger.info('visible');
 
-      logger.info('Info message');
-      expect(consoleLogSpy).toHaveBeenCalled();
-
-      logger.debug('Debug message');
-      expect(consoleDebugSpy).not.toHaveBeenCalled();
+      expect(entries().map(({ level }) => level)).toEqual(['info']);
     });
 
-    it('should ignore invalid log level in RATE_LIMIT_FALLBACK_LOG_LEVEL', () => {
+    it('ignores an invalid environment override', () => {
       process.env.RATE_LIMIT_FALLBACK_LOG_LEVEL = 'invalid' as LogLevel;
+      const logger = createTestLogger({ level: 'warn' });
 
-      const logger = new Logger({ level: 'warn' }, 'TestComponent');
+      logger.info('hidden');
+      logger.warn('visible');
 
-      logger.info('Info message');
-      expect(consoleLogSpy).not.toHaveBeenCalled();
-
-      logger.warn('Warning message');
-      expect(consoleWarnSpy).toHaveBeenCalled();
-    });
-
-    it('should override to silent level with RATE_LIMIT_FALLBACK_LOG_LEVEL', () => {
-      process.env.RATE_LIMIT_FALLBACK_LOG_LEVEL = 'silent';
-
-      const logger = new Logger({ level: 'debug' }, 'TestComponent');
-
-      logger.debug('Debug message');
-      expect(consoleDebugSpy).not.toHaveBeenCalled();
-
-      logger.error('Error message');
-      expect(consoleErrorSpy).not.toHaveBeenCalled();
+      expect(entries().map(({ level }) => level)).toEqual(['warn']);
     });
   });
 
-  describe('process.env.DEBUG Flag', () => {
-    it('should NOT output debug logs when process.env.DEBUG is not set', () => {
-      const logger = new Logger({ level: 'debug' }, 'TestComponent');
+  describe('formatting', () => {
+    it('uses the simple format with a timestamp by default', () => {
+      const logger = createTestLogger({ level: 'info', format: 'simple' });
 
-      logger.debug('Debug message');
-      expect(consoleDebugSpy).not.toHaveBeenCalled();
-    });
-
-    it('should output debug logs when process.env.DEBUG is set', () => {
-      process.env.DEBUG = '1';
-
-      const logger = new Logger({ level: 'debug' }, 'TestComponent');
-
-      logger.debug('Debug message');
-      expect(consoleDebugSpy).toHaveBeenCalled();
-    });
-
-    it('should allow other log levels when process.env.DEBUG is not set', () => {
-      const logger = new Logger({ level: 'debug' }, 'TestComponent');
-
-      logger.info('Info message');
-      expect(consoleLogSpy).toHaveBeenCalled();
-
-      logger.warn('Warning message');
-      expect(consoleWarnSpy).toHaveBeenCalled();
-
-      logger.error('Error message');
-      expect(consoleErrorSpy).toHaveBeenCalled();
-    });
-
-    it('should output all logs including debug when process.env.DEBUG is set', () => {
-      process.env.DEBUG = '1';
-
-      const logger = new Logger({ level: 'debug' }, 'TestComponent');
-
-      logger.debug('Debug message');
-      expect(consoleDebugSpy).toHaveBeenCalled();
-
-      logger.info('Info message');
-      expect(consoleLogSpy).toHaveBeenCalled();
-
-      logger.warn('Warning message');
-      expect(consoleWarnSpy).toHaveBeenCalled();
-
-      logger.error('Error message');
-      expect(consoleErrorSpy).toHaveBeenCalled();
-    });
-  });
-
-  describe('Default Config', () => {
-    it('should use default config when no config is provided', () => {
-      const logger = new Logger({}, 'TestComponent');
-
-      // Default level is warn
-      logger.warn('Warning message');
-      expect(consoleWarnSpy).toHaveBeenCalled();
-
-      logger.info('Info message');
-      expect(consoleLogSpy).not.toHaveBeenCalled();
-    });
-
-    it('should use default component name when not provided', () => {
-      const logger = new Logger({ level: 'info' });
       logger.info('Test message');
 
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining('[RateLimitFallback]')
+      expect(entries()[0].message).toMatch(
+        /^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\] \[INFO\] \[TestComponent\] Test message$/,
       );
     });
-  });
 
-  describe('Console Method Selection', () => {
-    it('should use console.error for error level', () => {
-      const logger = new Logger({ level: 'error' }, 'TestComponent');
-      logger.error('Error message');
-
-      expect(consoleErrorSpy).toHaveBeenCalled();
-      expect(consoleLogSpy).not.toHaveBeenCalled();
-      expect(consoleWarnSpy).not.toHaveBeenCalled();
-      expect(consoleDebugSpy).not.toHaveBeenCalled();
-    });
-
-    it('should use console.warn for warn level', () => {
-      const logger = new Logger({ level: 'warn' }, 'TestComponent');
-      logger.warn('Warning message');
-
-      expect(consoleWarnSpy).toHaveBeenCalled();
-      expect(consoleErrorSpy).not.toHaveBeenCalled();
-      expect(consoleLogSpy).not.toHaveBeenCalled();
-      expect(consoleDebugSpy).not.toHaveBeenCalled();
-    });
-
-    it('should use console.debug for debug level', () => {
-      process.env.DEBUG = '1';
-      const logger = new Logger({ level: 'debug' }, 'TestComponent');
-      logger.debug('Debug message');
-
-      expect(consoleDebugSpy).toHaveBeenCalled();
-      expect(consoleErrorSpy).not.toHaveBeenCalled();
-      expect(consoleWarnSpy).not.toHaveBeenCalled();
-      expect(consoleLogSpy).not.toHaveBeenCalled();
-    });
-
-    it('should use console.log for info level', () => {
-      const logger = new Logger({ level: 'info' }, 'TestComponent');
-      logger.info('Info message');
-
-      expect(consoleLogSpy).toHaveBeenCalled();
-      expect(consoleErrorSpy).not.toHaveBeenCalled();
-      expect(consoleWarnSpy).not.toHaveBeenCalled();
-      expect(consoleDebugSpy).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('Error Handling', () => {
-    it('should handle log output errors gracefully', () => {
-      // Make console.error throw an error
-      consoleErrorSpy.mockImplementation(() => {
-        throw new Error('Console error');
+    it('omits the timestamp when disabled', () => {
+      const logger = createTestLogger({
+        level: 'info',
+        format: 'simple',
+        enableTimestamp: false,
       });
 
-      const logger = new Logger({ level: 'error' }, 'TestComponent');
+      logger.info('Test message');
 
-      // Should not throw an error even if console.error throws
-      expect(() => logger.error('Error message')).not.toThrow();
+      expect(entries()[0].message).toBe('[INFO] [TestComponent] Test message');
     });
 
-    it('should handle formatting errors gracefully', () => {
-      // This is a bit tricky to test since format() is private
-      // But we can test that logging doesn't throw even with unusual metadata
-      const logger = new Logger({ level: 'info', format: 'json' }, 'TestComponent');
+    it('uses JSON format and includes metadata', () => {
+      const logger = createTestLogger({ level: 'info', format: 'json' });
 
-      // Circular reference could potentially cause issues, but should be handled
-      const circular: any = { a: 1 };
-      circular.self = circular;
+      logger.info('Test message', { requestId: '123', count: 2 });
 
-      expect(() => logger.info('Test message', circular)).not.toThrow();
-    });
-  });
-
-  describe('createLogger Helper', () => {
-    it('should create a Logger instance', () => {
-      const logger = createLogger({ level: 'info' }, 'TestComponent');
-
-      expect(logger).toBeInstanceOf(Logger);
+      expect(JSON.parse(entries()[0].message)).toMatchObject({
+        level: 'info',
+        component: 'TestComponent',
+        message: 'Test message',
+        requestId: '123',
+        count: 2,
+      });
+      expect(entries()[0].meta).toEqual({ requestId: '123', count: 2 });
     });
 
-    it('should use default component name when not specified', () => {
-      const logger = createLogger({ level: 'info' });
+    it('omits the JSON timestamp when disabled', () => {
+      const logger = createTestLogger({
+        level: 'info',
+        format: 'json',
+        enableTimestamp: false,
+      });
 
-      expect(logger).toBeInstanceOf(Logger);
+      logger.info('Test message');
+
+      expect(JSON.parse(entries()[0].message)).not.toHaveProperty('timestamp');
     });
 
-    it('should accept partial config', () => {
-      const logger = createLogger({ level: 'debug' });
+    it('uses the default component name', () => {
+      const logger = new Logger({ level: 'info' }, undefined, sink as LogSink);
 
-      logger.error('Error message');
-      expect(consoleErrorSpy).toHaveBeenCalled();
-    });
-  });
+      logger.info('Test message');
 
-  describe('Metadata Handling', () => {
-    it('should handle empty metadata', () => {
-      const logger = new Logger({ level: 'info', format: 'simple' }, 'TestComponent');
-      logger.info('Test message', {});
-
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Test message')
-      );
-    });
-
-    it('should handle undefined metadata', () => {
-      const logger = new Logger({ level: 'info', format: 'simple' }, 'TestComponent');
-      logger.info('Test message', undefined);
-
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Test message')
-      );
-    });
-
-    it('should include metadata in JSON format', () => {
-      const logger = new Logger({ level: 'info', format: 'json' }, 'TestComponent');
-      logger.info('Test message', { key: 'value', number: 123 });
-
-      const output = consoleLogSpy.mock.calls[0][0] as string;
-      const parsed = JSON.parse(output);
-
-      expect(parsed.key).toBe('value');
-      expect(parsed.number).toBe(123);
-    });
-
-    it('should ignore metadata in simple format', () => {
-      const logger = new Logger({ level: 'info', format: 'simple' }, 'TestComponent');
-      logger.info('Test message', { key: 'value' });
-
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringMatching(/Test message$/)
-      );
-      expect(consoleLogSpy).not.toHaveBeenCalledWith(
-        expect.stringContaining('key')
-      );
+      expect(entries()[0]).toMatchObject({ component: 'RateLimitFallback' });
+      expect(entries()[0].message).toContain('[RateLimitFallback]');
     });
   });
 
-  describe('Log Level Boundary Values', () => {
-    it('should output error logs at all levels except silent', () => {
-      const levels: LogLevel[] = ['debug', 'info', 'warn', 'error'];
+  describe('sink behavior', () => {
+    it('does not call console methods when no sink is provided', () => {
+      const consoleSpies = [
+        vi.spyOn(console, 'log').mockImplementation(() => undefined),
+        vi.spyOn(console, 'warn').mockImplementation(() => undefined),
+        vi.spyOn(console, 'error').mockImplementation(() => undefined),
+        vi.spyOn(console, 'debug').mockImplementation(() => undefined),
+      ];
+      const logger = new Logger({ level: 'info' }, 'TestComponent');
 
-      for (const level of levels) {
-        const logger = new Logger({ level }, 'TestComponent');
-        consoleErrorSpy.mockClear();
+      logger.info('info');
+      logger.warn('warn');
+      logger.error('error');
 
-        logger.error('Error message');
-        expect(consoleErrorSpy).toHaveBeenCalled();
+      for (const consoleSpy of consoleSpies) {
+        expect(consoleSpy).not.toHaveBeenCalled();
       }
     });
 
-    it('should respect silent level boundary (no logs at silent)', () => {
-      const logger = new Logger({ level: 'silent' }, 'TestComponent');
+    it('swallows synchronous sink failures', () => {
+      const failingSink: LogSink = () => {
+        throw new Error('sink failed');
+      };
+      const logger = new Logger({ level: 'error' }, 'TestComponent', failingSink);
 
-      logger.error('Error message');
-      expect(consoleErrorSpy).not.toHaveBeenCalled();
+      expect(() => logger.error('Error message')).not.toThrow();
     });
 
-    it('should only output info+ at info level', () => {
-      const logger = new Logger({ level: 'info' }, 'TestComponent');
+    it('handles rejected sink promises', async () => {
+      const failingSink: LogSink = () => Promise.reject(new Error('sink failed'));
+      const logger = new Logger({ level: 'info' }, 'TestComponent', failingSink);
 
-      logger.debug('Debug message');
-      expect(consoleDebugSpy).not.toHaveBeenCalled();
-
-      logger.info('Info message');
-      expect(consoleLogSpy).toHaveBeenCalled();
-
-      logger.warn('Warning message');
-      expect(consoleWarnSpy).toHaveBeenCalled();
-
-      logger.error('Error message');
-      expect(consoleErrorSpy).toHaveBeenCalled();
-    });
-  });
-
-  describe('Component Name', () => {
-    it('should use custom component name', () => {
-      const logger = new Logger({ level: 'info' }, 'CustomComponent');
-      logger.info('Test message');
-
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringContaining('[CustomComponent]')
-      );
+      expect(() => logger.info('Info message')).not.toThrow();
+      await Promise.resolve();
     });
 
-    it('should include component name in simple format', () => {
-      const logger = new Logger({ level: 'info', format: 'simple' }, 'TestComponent');
-      logger.info('Test message');
+    it('swallows formatting failures', () => {
+      const logger = createTestLogger({ level: 'info', format: 'json' });
+      const circular: Record<string, unknown> = {};
+      circular.self = circular;
 
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        expect.stringMatching(/\[INFO\] \[TestComponent\]/)
-      );
+      expect(() => logger.info('Test message', circular)).not.toThrow();
+      expect(sink).not.toHaveBeenCalled();
     });
 
-    it('should include component name in JSON format', () => {
-      const logger = new Logger({ level: 'info', format: 'json' }, 'TestComponent');
-      logger.info('Test message');
+    it('passes the sink through createLogger', () => {
+      const logger = createLogger({ level: 'warn' }, 'CustomComponent', sink as LogSink);
 
-      const output = consoleLogSpy.mock.calls[0][0] as string;
-      const parsed = JSON.parse(output);
+      logger.warn('Warning message', { source: 'test' });
 
-      expect(parsed.component).toBe('TestComponent');
+      expect(entries()[0]).toMatchObject({
+        level: 'warn',
+        component: 'CustomComponent',
+        meta: { source: 'test' },
+      });
     });
   });
 });

--- a/__tests__/metrics.test.ts
+++ b/__tests__/metrics.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { createLogger } from '../logger';
+import { createLogger, type LogEntry, type LogSink } from '../logger';
 import { MetricsManager } from '../src/metrics/MetricsManager';
 import type { MetricsConfig } from '../src/types';
 
@@ -13,13 +13,13 @@ import { writeFileSync } from 'fs';
 describe('MetricsManager', () => {
   let metricsManager: MetricsManager;
   let logger: ReturnType<typeof createLogger>;
-  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let logSink: ReturnType<typeof vi.fn>;
   let writeFileSyncSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    logSink = vi.fn();
     writeFileSyncSpy = vi.mocked(writeFileSync).mockImplementation(() => {});
-    logger = createLogger({ level: 'silent' }, 'MetricsTest');
+    logger = createLogger({ level: 'info' }, 'MetricsTest', logSink as LogSink);
   });
 
   afterEach(() => {
@@ -555,15 +555,78 @@ describe('MetricsManager', () => {
       metricsManager = new MetricsManager(config, logger);
     });
 
-    it('should log to console when enabled', async () => {
+    it('should write to the structured log sink when enabled', async () => {
       metricsManager.recordRateLimit('anthropic', 'claude-3-5-sonnet-20250514');
       
       await metricsManager.report();
 
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(logSink).toHaveBeenCalled();
+      const entry = logSink.mock.calls.at(-1)?.[0] as LogEntry;
+      expect(entry.meta).toEqual({ source: 'metrics-report' });
+      expect(entry.message).toContain('Rate Limit Fallback Metrics');
     });
 
-    it('should not log to console when disabled', async () => {
+    it('should preserve JSON output with a simple logger', async () => {
+      const localSink = vi.fn();
+      const localLogger = createLogger(
+        { level: 'warn', format: 'simple' },
+        'MetricsTest',
+        localSink as LogSink,
+      );
+      metricsManager = new MetricsManager({
+        enabled: true,
+        output: { console: true, format: 'json' },
+        resetInterval: 'daily',
+      }, localLogger);
+
+      await metricsManager.report();
+
+      const entry = localSink.mock.calls[0][0] as LogEntry;
+      expect(JSON.parse(entry.message)).toHaveProperty('rateLimits');
+      expect(entry.message).not.toContain('[INFO]');
+    });
+
+    it('should not double-wrap JSON output with a JSON logger', async () => {
+      const localSink = vi.fn();
+      const localLogger = createLogger(
+        { level: 'silent', format: 'json' },
+        'MetricsTest',
+        localSink as LogSink,
+      );
+      metricsManager = new MetricsManager({
+        enabled: true,
+        output: { console: true, format: 'json' },
+        resetInterval: 'daily',
+      }, localLogger);
+
+      await metricsManager.report();
+
+      expect(localSink).toHaveBeenCalledTimes(1);
+      const parsed = JSON.parse((localSink.mock.calls[0][0] as LogEntry).message);
+      expect(parsed).toHaveProperty('rateLimits');
+      expect(parsed).not.toHaveProperty('message');
+    });
+
+    it('should preserve the first line of CSV output', async () => {
+      const localSink = vi.fn();
+      const localLogger = createLogger(
+        { level: 'warn', format: 'simple' },
+        'MetricsTest',
+        localSink as LogSink,
+      );
+      metricsManager = new MetricsManager({
+        enabled: true,
+        output: { console: true, format: 'csv' },
+        resetInterval: 'daily',
+      }, localLogger);
+
+      await metricsManager.report();
+
+      const entry = localSink.mock.calls[0][0] as LogEntry;
+      expect(entry.message.split('\n')[0]).toBe('=== RATE_LIMITS ===');
+    });
+
+    it('should not write to the log sink when disabled', async () => {
       const config: MetricsConfig = {
         enabled: true,
         output: { console: false, format: 'json' },
@@ -573,7 +636,7 @@ describe('MetricsManager', () => {
 
       await metricsManager.report();
 
-      expect(consoleSpy).not.toHaveBeenCalled();
+      expect(logSink).not.toHaveBeenCalled();
     });
 
     it('should not report when disabled', async () => {
@@ -586,7 +649,7 @@ describe('MetricsManager', () => {
 
       await metricsManager.report();
 
-      expect(consoleSpy).not.toHaveBeenCalled();
+      expect(logSink).not.toHaveBeenCalled();
     });
 
     it('should write to file when specified', async () => {

--- a/__tests__/metrics/metricsmanager.test.ts
+++ b/__tests__/metrics/metricsmanager.test.ts
@@ -12,6 +12,7 @@ describe('MetricsManager', () => {
       info: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
+      emitRaw: vi.fn(),
     } as unknown as Logger;
 
     metricsManager = new MetricsManager(
@@ -378,12 +379,14 @@ describe('MetricsManager', () => {
   });
 
   describe('report()', () => {
-    it('should log to console when enabled', () => {
-      const logSpy = vi.spyOn(console, 'log');
+    it('should write to the structured logger when enabled', async () => {
+      await metricsManager.report();
 
-      metricsManager.report().then(() => {
-        expect(logSpy).toHaveBeenCalled();
-      });
+      expect(mockLogger.emitRaw).toHaveBeenCalledWith(
+        'info',
+        expect.stringContaining('"rateLimits"'),
+        { source: 'metrics-report' },
+      );
     });
 
     it('should not throw when writing to file fails', async () => {

--- a/index.ts
+++ b/index.ts
@@ -5,7 +5,7 @@
  */
 
 import type { Plugin } from "@opencode-ai/plugin";
-import { createLogger } from "./logger.js";
+import { createLogger, type LogSink } from "./logger.js";
 
 // Import modular components
 import type {
@@ -107,6 +107,20 @@ function isSubagentSessionCreatedEvent(event: { type: string; properties?: unkno
 // ============================================================================
 
 export const RateLimitFallback: Plugin = async ({ client, directory, worktree }) => {
+  const openCodeLogSink: LogSink = ({ level, component, message, meta }) => (
+    client.app.log({
+      body: {
+        service: "opencode-rate-limit-fallback",
+        level,
+        message,
+        extra: {
+          component,
+          ...meta,
+        },
+      },
+    })
+  );
+
   // Detect headless mode (no TUI) before loading config for logging
   const isHeadless = !client.tui;
 
@@ -117,7 +131,7 @@ export const RateLimitFallback: Plugin = async ({ client, directory, worktree })
     format: 'simple',
     enableTimestamp: true,
   };
-  const tempLogger = createLogger(tempLogConfig, "RateLimitFallback");
+  const tempLogger = createLogger(tempLogConfig, "RateLimitFallback", openCodeLogSink);
 
   // Log headless mode detection
   if (isHeadless) {
@@ -134,7 +148,7 @@ export const RateLimitFallback: Plugin = async ({ client, directory, worktree })
   };
 
   // Create final logger instance with loaded config
-  const logger = createLogger(logConfig, "RateLimitFallback");
+  const logger = createLogger(logConfig, "RateLimitFallback", openCodeLogSink);
 
   if (configSource) {
     logger.info(`Config loaded from: ${configSource}`);
@@ -353,13 +367,6 @@ export const RateLimitFallback: Plugin = async ({ client, directory, worktree })
 
   return {
     event: async ({ event }) => {
-      // Debug: log all events to identify how "Free usage exceeded" arrives
-      const rawEvt = event as { type: string; properties?: unknown };
-      const evtJson = JSON.stringify(rawEvt, null, 0);
-      if (evtJson.toLowerCase().includes("exceeded") || evtJson.toLowerCase().includes("free usage") || evtJson.toLowerCase().includes("credits")) {
-        logger.info("DEBUG rate-limit-related event", { type: rawEvt.type, properties: rawEvt.properties });
-      }
-
       // Handle session.error events
       if (isSessionErrorEvent(event)) {
         const { sessionID, error } = event.properties;

--- a/logger.ts
+++ b/logger.ts
@@ -15,6 +15,17 @@ export interface LogMeta {
   [key: string]: unknown;
 }
 
+export type LogOutputLevel = Exclude<LogLevel, "silent">;
+
+export interface LogEntry {
+  level: LogOutputLevel;
+  component: string;
+  message: string;
+  meta?: LogMeta;
+}
+
+export type LogSink = (entry: LogEntry) => void | Promise<unknown>;
+
 const DEFAULT_LOG_CONFIG: LogConfig = {
   level: "warn",
   format: "simple",
@@ -28,6 +39,8 @@ const LEVEL_PRIORITY: Record<LogLevel, number> = {
   error: 3,
   silent: 4,
 };
+
+const NOOP_LOG_SINK: LogSink = () => undefined;
 
 /**
  * Simple formatter for text-based log output
@@ -70,8 +83,13 @@ export class Logger {
   private component: string;
   private simpleFormatter: SimpleFormatter;
   private jsonFormatter: JsonFormatter;
+  private sink: LogSink;
 
-  constructor(config: Partial<LogConfig> = {}, component: string = "RateLimitFallback") {
+  constructor(
+    config: Partial<LogConfig> = {},
+    component: string = "RateLimitFallback",
+    sink: LogSink = NOOP_LOG_SINK,
+  ) {
     // Apply environment variable override if set
     const envLogLevel = process.env.RATE_LIMIT_FALLBACK_LOG_LEVEL as LogLevel | undefined;
 
@@ -88,6 +106,7 @@ export class Logger {
     this.component = component;
     this.simpleFormatter = new SimpleFormatter();
     this.jsonFormatter = new JsonFormatter();
+    this.sink = sink;
   }
 
   /**
@@ -120,29 +139,34 @@ export class Logger {
   }
 
   /**
-   * Select appropriate console method based on log level
+   * Write a prepared record to the configured sink.
    */
-  private getConsoleMethod(level: LogLevel): typeof console.log {
-    if (level === "error") return console.error;
-    if (level === "warn") return console.warn;
-    if (level === "debug") return console.debug;
-    return console.log;
+  private write(level: LogOutputLevel, message: string, meta?: LogMeta): void {
+    try {
+      const result = this.sink({
+        level,
+        component: this.component,
+        message,
+        meta,
+      });
+
+      if (result) {
+        void result.catch(() => undefined);
+      }
+    } catch {
+      // Silently ignore log output errors - don't let logging break the plugin
+    }
   }
 
-  /**
-   * Core log method - handles all log levels
-   */
-  private log(level: LogLevel, message: string, meta?: LogMeta): void {
+  private log(level: LogOutputLevel, message: string, meta?: LogMeta): void {
     if (!this.shouldLog(level)) {
       return;
     }
 
     try {
-      const formatted = this.format(level, message, meta);
-      const consoleMethod = this.getConsoleMethod(level);
-      consoleMethod(formatted);
+      this.write(level, this.format(level, message, meta), meta);
     } catch {
-      // Silently ignore log output errors - don't let logging break the plugin
+      // Silently ignore formatting errors - don't let logging break the plugin
     }
   }
 
@@ -173,11 +197,22 @@ export class Logger {
   error(message: string, meta?: LogMeta): void {
     this.log("error", message, meta);
   }
+
+  /**
+   * Emit explicitly requested output without level filtering or message formatting.
+   */
+  emitRaw(level: LogOutputLevel, message: string, meta?: LogMeta): void {
+    this.write(level, message, meta);
+  }
 }
 
 /**
  * Create a new logger instance
  */
-export function createLogger(config?: Partial<LogConfig>, component?: string): Logger {
-  return new Logger(config, component);
+export function createLogger(
+  config?: Partial<LogConfig>,
+  component?: string,
+  sink?: LogSink,
+): Logger {
+  return new Logger(config, component, sink);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azumag/opencode-rate-limit-fallback",
-  "version": "1.70.5",
+  "version": "1.70.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azumag/opencode-rate-limit-fallback",
-      "version": "1.70.5",
+      "version": "1.70.6",
       "license": "MIT",
       "dependencies": {
         "@opencode-ai/plugin": "1.18.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azumag/opencode-rate-limit-fallback",
-  "version": "1.70.5",
+  "version": "1.70.6",
   "description": "OpenCode plugin that automatically switches to fallback models when rate limited",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/circuitbreaker/CircuitBreaker.ts
+++ b/src/circuitbreaker/CircuitBreaker.ts
@@ -180,7 +180,7 @@ export class CircuitBreaker {
             variant: "warning",
             duration: 5000,
           },
-        });
+        }, this.logger);
         break;
       case 'HALF_OPEN':
         safeShowToast(this.client, {
@@ -190,7 +190,7 @@ export class CircuitBreaker {
             variant: "info",
             duration: 3000,
           },
-        });
+        }, this.logger);
         break;
       case 'CLOSED':
         // Only show toast for circuit close when transitioning from non-CLOSED state
@@ -202,7 +202,7 @@ export class CircuitBreaker {
               variant: "success",
               duration: 3000,
             },
-          });
+          }, this.logger);
         }
         break;
     }

--- a/src/fallback/FallbackHandler.ts
+++ b/src/fallback/FallbackHandler.ts
@@ -74,7 +74,7 @@ export class FallbackHandler {
       this.dynamicPrioritizer = new DynamicPrioritizer(dynamicConfig, healthTracker, logger, metricsManager);
     }
 
-    this.modelSelector = new ModelSelector(config, client, this.circuitBreaker, healthTracker, this.dynamicPrioritizer);
+    this.modelSelector = new ModelSelector(config, client, this.circuitBreaker, healthTracker, this.dynamicPrioritizer, logger);
 
     this.currentSessionModel = new Map();
     this.modelRequestStartTimes = new Map();
@@ -204,7 +204,7 @@ export class FallbackHandler {
         variant: "success",
         duration: 3000,
       },
-    });
+    }, this.logger);
   }
 
   /**
@@ -251,7 +251,7 @@ export class FallbackHandler {
           variant: "warning",
           duration: 3000,
         },
-      });
+      }, this.logger);
 
       // Get messages from the session
       const messagesResult = await this.client.session.messages({ path: { id: targetSessionID } });
@@ -296,7 +296,7 @@ export class FallbackHandler {
             variant: "error",
             duration: 5000,
           },
-        });
+        }, this.logger);
         this.logger.warn('Retry exhausted', { sessionID: dedupSessionID, messageID: lastUserMessage.info.id });
         this.retryState.delete(stateKey);
         this.fallbackInProgress.delete(fallbackKey);
@@ -331,7 +331,7 @@ export class FallbackHandler {
             variant: "error",
             duration: 5000,
           },
-        });
+        }, this.logger);
         this.retryState.delete(stateKey);
         this.fallbackInProgress.delete(fallbackKey);
         return;
@@ -363,7 +363,7 @@ export class FallbackHandler {
           variant: "info",
           duration: 3000,
         },
-      });
+      }, this.logger);
 
       // Record fallback start time
       if (this.metricsManager) {

--- a/src/fallback/ModelSelector.ts
+++ b/src/fallback/ModelSelector.ts
@@ -6,6 +6,7 @@ import type { FallbackModel, PluginConfig, OpenCodeClient } from '../types/index
 import type { CircuitBreaker } from '../circuitbreaker/index.js';
 import type { HealthTracker } from '../health/HealthTracker.js';
 import type { DynamicPrioritizer } from '../dynamic/DynamicPrioritizer.js';
+import type { Logger } from '../../logger.js';
 import { getModelKey } from '../utils/helpers.js';
 import { safeShowToast } from '../utils/helpers.js';
 
@@ -19,19 +20,22 @@ export class ModelSelector {
   private circuitBreaker?: CircuitBreaker;
   private healthTracker?: HealthTracker;
   private dynamicPrioritizer?: DynamicPrioritizer;
+  private logger?: Logger;
 
   constructor(
     config: PluginConfig,
     client: OpenCodeClient,
     circuitBreaker?: CircuitBreaker,
     healthTracker?: HealthTracker,
-    dynamicPrioritizer?: DynamicPrioritizer
+    dynamicPrioritizer?: DynamicPrioritizer,
+    logger?: Logger,
   ) {
     this.config = config;
     this.client = client;
     this.circuitBreaker = circuitBreaker;
     this.healthTracker = healthTracker;
     this.dynamicPrioritizer = dynamicPrioritizer;
+    this.logger = logger;
     this.rateLimitedModels = new Map();
   }
 
@@ -148,7 +152,7 @@ export class ModelSelector {
               variant: "warning",
               duration: 3000,
             },
-          });
+          }, this.logger);
           return lastModel;
         } else {
           // Last model also failed, reset for next prompt

--- a/src/main/ConfigReloader.ts
+++ b/src/main/ConfigReloader.ts
@@ -327,7 +327,7 @@ export class ConfigReloader {
         variant: 'success',
         duration: 3000,
       },
-    });
+    }, this.logger);
   }
 
   /**
@@ -341,6 +341,6 @@ export class ConfigReloader {
         variant: 'error',
         duration: 5000,
       },
-    });
+    }, this.logger);
   }
 }

--- a/src/metrics/MetricsManager.ts
+++ b/src/metrics/MetricsManager.ts
@@ -713,9 +713,9 @@ export class MetricsManager {
 
     const output = this.export(this.config.output.format);
 
-    // Console output
+    // Structured application log output
     if (this.config.output.console) {
-      console.log(output);
+      this.logger.emitRaw('info', output, { source: 'metrics-report' });
     }
 
     // File output

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -3,6 +3,7 @@
  */
 
 import type { MessagePart, SDKMessagePartInput, ToastMessage, OpenCodeClient } from '../types/index.js';
+import type { Logger } from '../../logger.js';
 import {
   DEDUP_WINDOW_MS as DEDUP_WINDOW_MS_TYPE,
   STATE_TIMEOUT_MS as STATE_TIMEOUT_MS_TYPE,
@@ -74,30 +75,35 @@ export function getToastMessage(toast: ToastMessage): { title: string; message: 
 }
 
 /**
- * Safely show toast, falling back to console logging if TUI is missing or fails
+ * Safely show toast, falling back to the plugin logger if TUI is missing or fails
  */
-export const safeShowToast = async (client: OpenCodeClient, toast: ToastMessage) => {
+export const safeShowToast = async (client: OpenCodeClient, toast: ToastMessage, logger?: Logger) => {
   const { title, message, variant } = getToastMessage(toast);
 
-  const logToConsole = () => {
-    if (variant === "error") {
-      console.error(`[RateLimitFallback] ${title}: ${message}`);
-    } else if (variant === "warning") {
-      console.warn(`[RateLimitFallback] ${title}: ${message}`);
-    } else {
-      console.log(`[RateLimitFallback] ${title}: ${message}`);
-    }
+  const logFallback = (error?: unknown) => {
+    if (!logger) return;
+
+    const fallbackMessage = `Toast unavailable: ${title}${message ? `: ${message}` : ''}`;
+    const meta = {
+      toastVariant: variant,
+      ...(error ? { error: error instanceof Error ? error.message : String(error) } : {}),
+    };
+
+    const level = variant === "error"
+      ? "error"
+      : variant === "warning"
+        ? "warn"
+        : "info";
+    logger.emitRaw(level, fallbackMessage, meta);
   };
 
   try {
     if (client.tui) {
       await client.tui.showToast(toast);
     } else {
-      // TUI doesn't exist - log to console
-      logToConsole();
+      logFallback();
     }
-  } catch {
-    // TUI exists but failed to show toast - log to console
-    logToConsole();
+  } catch (error) {
+    logFallback(error);
   }
 };


### PR DESCRIPTION
## Summary

- route plugin diagnostics through OpenCode's official `client.app.log` API instead of `console.*`
- make toast failures and explicit metrics output use the same structured sink without losing info/success messages or JSON/CSV formatting
- remove the temporary full-event JSON debug logger so unrelated event bodies are never serialized into diagnostics
- document the application-log behavior and bump the package to 1.70.6

Fixes #23

## Validation

- `npm run typecheck`
- `npm run build`
- `npm test` (614 passed, 15 skipped)
- `npm run test:coverage` / targeted logger coverage: 100% statements, functions, and branches
- `npm audit` (0 vulnerabilities)
- `npm pack --dry-run --json`
- built `dist` scan: no `console.log/info/warn/error/debug`
- real `@opencode-ai/sdk@1.18.16` client against a local HTTP server: one `/log` request, zero console calls
- independent Sol review: approved with no remaining findings

OpenCode's plugin guide explicitly recommends `client.app.log()` for structured plugin logging: https://opencode.ai/docs/plugins/#logging
