### PR TITLE
fix: preserve agent across fallback retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ OpenCode plugin that automatically switches to fallback models when rate limited
 - Detects rate limit errors (429, `rate_limit_error`, "usage limit", "quota exceeded", "high concurrency", etc.)
 - Ignores known benign Anthropic billing notices so they do not trigger false-positive fallbacks
 - Automatically aborts the current request and retries with a fallback model
+- Preserves the active OpenCode agent (`build`, `plan`, or a custom agent) when retrying
 - Configurable fallback model list with priority order
 - Three fallback modes: `cycle`, `stop`, and `retry-last`
 - **Headless mode support** (`opencode run`): disable fallback or abort on rate limit

--- a/__tests__/fallback/fallbackhandler.test.ts
+++ b/__tests__/fallback/fallbackhandler.test.ts
@@ -288,6 +288,83 @@ describe('FallbackHandler', () => {
     });
   });
 
+  describe('Agent persistence', () => {
+    it.each(['build', 'plan', 'custom-reviewer'])('forwards the %s agent from the last user message', async (agent) => {
+      mockClient.session.messages = vi.fn().mockResolvedValue({
+        data: [
+          {
+            info: { id: 'user-1', role: 'user', agent },
+            parts: [{ type: 'text', text: 'Continue the task' }],
+          },
+        ],
+      });
+      const retrySpy = vi.spyOn(fallbackHandler, 'retryWithModel').mockResolvedValue(undefined);
+
+      await fallbackHandler.handleRateLimitFallback(
+        'session-1',
+        'anthropic',
+        'claude-3-5-sonnet-20250514',
+      );
+
+      expect(retrySpy).toHaveBeenCalledWith(
+        'session-1',
+        { providerID: 'google', modelID: 'gemini-2.5-pro' },
+        [{ type: 'text', text: 'Continue the task' }],
+        null,
+        agent,
+      );
+    });
+
+    it('includes the original agent in promptAsync', async () => {
+      vi.useFakeTimers();
+
+      try {
+        const retry = fallbackHandler.retryWithModel(
+          'session-1',
+          { providerID: 'google', modelID: 'gemini-2.5-pro' },
+          [{ type: 'text', text: 'Continue the task' }],
+          null,
+          'build',
+        );
+        await Promise.resolve();
+        await vi.advanceTimersByTimeAsync(500);
+        await retry;
+
+        expect(mockClient.session.promptAsync).toHaveBeenCalledWith({
+          path: { id: 'session-1' },
+          body: {
+            parts: [{ type: 'text', text: 'Continue the task' }],
+            model: { providerID: 'google', modelID: 'gemini-2.5-pro' },
+            agent: 'build',
+          },
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('omits agent when older message data does not provide one', async () => {
+      vi.useFakeTimers();
+
+      try {
+        const retry = fallbackHandler.retryWithModel(
+          'session-1',
+          { providerID: 'google', modelID: 'gemini-2.5-pro' },
+          [{ type: 'text', text: 'Continue the task' }],
+          null,
+        );
+        await Promise.resolve();
+        await vi.advanceTimersByTimeAsync(500);
+        await retry;
+
+        const request = vi.mocked(mockClient.session.promptAsync).mock.calls[0][0];
+        expect(request.body).not.toHaveProperty('agent');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   describe('Concurrent Fallback Handling', () => {
     it('should handle concurrent fallback requests', async () => {
       mockSubagentTracker.getRootSession = vi.fn().mockReturnValue('root-session');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azumag/opencode-rate-limit-fallback",
-  "version": "1.70.6",
+  "version": "1.70.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azumag/opencode-rate-limit-fallback",
-      "version": "1.70.6",
+      "version": "1.70.7",
       "license": "MIT",
       "dependencies": {
         "@opencode-ai/plugin": "1.18.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azumag/opencode-rate-limit-fallback",
-  "version": "1.70.6",
+  "version": "1.70.7",
   "description": "OpenCode plugin that automatically switches to fallback models when rate limited",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/fallback/FallbackHandler.ts
+++ b/src/fallback/FallbackHandler.ts
@@ -133,7 +133,8 @@ export class FallbackHandler {
     targetSessionID: string,
     model: FallbackModel,
     parts: MessagePart[],
-    hierarchy: SessionHierarchy | null
+    hierarchy: SessionHierarchy | null,
+    agent?: string,
   ): Promise<void> {
     // Record model usage for dynamic prioritization
     if (this.dynamicPrioritizer) {
@@ -194,6 +195,7 @@ export class FallbackHandler {
       body: {
         parts: sdkParts,
         model: { providerID: model.providerID, modelID: model.modelID },
+        ...(agent ? { agent } : {}),
       },
     });
 
@@ -381,7 +383,13 @@ export class FallbackHandler {
       const retryStartTime = Date.now();
 
       // Retry with the selected model
-      await this.retryWithModel(dedupSessionID, nextModel, parts, hierarchy);
+      await this.retryWithModel(
+        dedupSessionID,
+        nextModel,
+        parts,
+        hierarchy,
+        lastUserMessage.info.agent,
+      );
 
       // Record health success for fallback model
       if (this.healthTracker) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -549,9 +549,9 @@ export interface ToastMessage {
 export type OpenCodeClient = {
   session: {
     abort: (args: { path: { id: string } }) => Promise<unknown>;
-    messages: (args: { path: { id: string } }) => Promise<{ data?: Array<{ info: { id: string; role: string }; parts: unknown[] }> }>;
-    prompt: (args: { path: { id: string }; body: { parts: SDKMessagePartInput[]; model: { providerID: string; modelID: string } } }) => Promise<unknown>;
-    promptAsync: (args: { path: { id: string }; body: { parts: SDKMessagePartInput[]; model: { providerID: string; modelID: string } } }) => Promise<unknown>;
+    messages: (args: { path: { id: string } }) => Promise<{ data?: Array<{ info: { id: string; role: string; agent?: string }; parts: unknown[] }> }>;
+    prompt: (args: { path: { id: string }; body: { parts: SDKMessagePartInput[]; model: { providerID: string; modelID: string }; agent?: string } }) => Promise<unknown>;
+    promptAsync: (args: { path: { id: string }; body: { parts: SDKMessagePartInput[]; model: { providerID: string; modelID: string }; agent?: string } }) => Promise<unknown>;
   };
   tui?: {
     showToast: (toast: ToastMessage) => Promise<unknown>;


### PR DESCRIPTION
## Summary

- preserve the last user message's OpenCode `agent` when queueing a fallback `promptAsync`
- omit the field for older message payloads that do not include an agent
- cover `build`, `plan`, custom agents, the final SDK request body, and the compatibility path
- document the behavior and bump the package to 1.70.7

Fixes #19

## Validation

- `npm run typecheck`
- `npm run build`
- `npm test` (619 passed, 15 skipped)
- `npm audit` (0 vulnerabilities)
- `npm pack --dry-run --json`
- real `@opencode-ai/sdk@1.18.16` client E2E: `session.error` → messages (`agent: build`) → abort → `prompt_async` (`agent: build`, fallback model)
- contract verified against both SDK 1.18.16 and the issue-era SDK 1.1.53
- independent Sol review: approved with no remaining findings
