### PR TITLE
fix: retry rate-limited subagent sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ OpenCode plugin that automatically switches to fallback models when rate limited
   - Configurable retry limits and timeouts
   - Retry statistics tracking
  - Toast notifications for user feedback
-  - Subagent session support with automatic fallback propagation to parent sessions
+  - Subagent session support with fallback on the failed child session
   - Configurable maximum subagent nesting depth
   - **Circuit breaker pattern** to prevent cascading failures from consistently failing models
   - **Metrics collection** to track rate limits, fallbacks, and model performance
@@ -429,8 +429,10 @@ The plugin supports automatic configuration reloading without requiring you to r
 - Fallback model list
 - Cooldown periods
 - Fallback mode
+- Subagent fallback and maximum-depth settings
 - Retry policies
 - Circuit breaker settings
+- Custom, ignored, and learned error patterns
 - Metrics configuration
 - Log configuration
 - Health tracking settings
@@ -602,10 +604,10 @@ Plugin automatically used Claude and Gemini models as fallbacks
 
 When OpenCode uses subagents (e.g., for complex tasks requiring specialized agents):
 
-- **Automatic Detection**: The plugin detects `subagent.session.created` events
+- **Automatic Detection**: The plugin detects child `session.created` events through `info.parentID`
 - **Hierarchy Tracking**: Maintains parent-child relationships between sessions
-- **Fallback Propagation**: When a subagent hits a rate limit, the fallback is triggered at the root session level
-- **Model Sharing**: All subagents in a hierarchy share the same fallback model
+- **Targeted Retry**: When a subagent hits a rate limit, only that child session is retried with the next model and the same agent
+- **Independent State**: Parent and sibling sessions keep their own active models and retry state
 
 ### Subagent Configuration
 
@@ -613,6 +615,10 @@ When OpenCode uses subagents (e.g., for complex tasks requiring specialized agen
 |--------|------|---------|-------------|
 | `maxSubagentDepth` | number | `10` | Maximum nesting depth for subagent hierarchies |
 | `enableSubagentFallback` | boolean | `true` | Enable/disable fallback for subagent sessions |
+
+Set `enableSubagentFallback` to `true` when you want child sessions created by
+`Task` or custom subagents to use the fallback list. With `false`, rate-limit
+events from tracked child sessions are left to OpenCode.
 
 ## Logging
 

--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -76,4 +76,49 @@ describe('config utilities', () => {
       'draw from your extra usage',
     ]);
   });
+
+  it('filters malformed custom and learned patterns before runtime use', () => {
+    const validCustom = {
+      name: 'provider-capacity',
+      patterns: ['capacity exhausted'],
+      priority: 90,
+    };
+    const validLearned = {
+      name: 'learned-capacity',
+      patterns: ['learned capacity signal'],
+      priority: 70,
+      confidence: 0.9,
+      learnedAt: '2026-08-12T00:00:00.000Z',
+      sampleCount: 4,
+    };
+    const config = validateConfig({
+      errorPatterns: {
+        custom: [null, {}, validCustom],
+        learnedPatterns: [{}, validLearned],
+      },
+    } as unknown as Partial<PluginConfig>);
+
+    expect(config.errorPatterns?.custom).toEqual([validCustom]);
+    expect(config.errorPatterns?.learnedPatterns).toEqual([validLearned]);
+  });
+
+  it('normalizes invalid subagent settings to safe defaults', () => {
+    const config = validateConfig({
+      maxSubagentDepth: 0,
+      enableSubagentFallback: 'yes',
+    } as unknown as Partial<PluginConfig>);
+
+    expect(config.maxSubagentDepth).toBe(10);
+    expect(config.enableSubagentFallback).toBe(true);
+  });
+
+  it('preserves valid subagent settings', () => {
+    const config = validateConfig({
+      maxSubagentDepth: 4,
+      enableSubagentFallback: false,
+    });
+
+    expect(config.maxSubagentDepth).toBe(4);
+    expect(config.enableSubagentFallback).toBe(false);
+  });
 });

--- a/__tests__/fallback/fallbackhandler.test.ts
+++ b/__tests__/fallback/fallbackhandler.test.ts
@@ -44,6 +44,8 @@ describe('FallbackHandler', () => {
     mockSubagentTracker = {
       getRootSession: vi.fn().mockReturnValue(null),
       getHierarchy: vi.fn().mockReturnValue(null),
+      isSubagent: vi.fn().mockReturnValue(false),
+      updateConfig: vi.fn(),
       trackSubagent: vi.fn(),
       cleanup: vi.fn(),
     } as unknown as SubagentTracker;
@@ -246,6 +248,7 @@ describe('FallbackHandler', () => {
       };
 
       expect(() => fallbackHandler.updateConfig(newConfig)).not.toThrow();
+      expect(mockSubagentTracker.updateConfig).toHaveBeenCalledWith(newConfig);
     });
 
     it('should recreate circuit breaker when enabled', () => {
@@ -428,7 +431,7 @@ describe('FallbackHandler', () => {
   });
 
   describe('Subagent Hierarchy Handling', () => {
-    it('should handle subagent fallback request', async () => {
+    it('should retry the failed subagent session instead of replaying the root prompt', async () => {
       const hierarchy: SessionHierarchy = {
         rootSessionID: 'root-session',
         sharedFallbackState: 'completed',
@@ -442,13 +445,45 @@ describe('FallbackHandler', () => {
 
       mockSubagentTracker.getRootSession = vi.fn().mockReturnValue('root-session');
       mockSubagentTracker.getHierarchy = vi.fn().mockReturnValue(hierarchy);
+      mockSubagentTracker.isSubagent = vi.fn().mockReturnValue(true);
       mockClient.session.messages = vi.fn().mockResolvedValue({
-        data: [],
+        data: [{
+          info: { id: 'child-message', role: 'user', agent: 'engram' },
+          parts: [{ type: 'text', text: 'child task' }],
+        }],
       });
 
-      await expect(
-        fallbackHandler.handleRateLimitFallback('subagent-1', 'anthropic', 'claude-3-5-sonnet-20250514')
-      ).resolves.not.toThrow();
+      await fallbackHandler.handleRateLimitFallback('subagent-1', 'anthropic', 'claude-3-5-sonnet-20250514');
+
+      expect(mockClient.session.messages).toHaveBeenCalledWith({ path: { id: 'subagent-1' } });
+      expect(mockClient.session.promptAsync).toHaveBeenCalledWith({
+        path: { id: 'subagent-1' },
+        body: {
+          parts: [{ type: 'text', text: 'child task' }],
+          model: { providerID: 'google', modelID: 'gemini-2.5-pro' },
+          agent: 'engram',
+        },
+      });
+    });
+
+    it('should skip a tracked subagent when subagent fallback is disabled', async () => {
+      fallbackHandler.updateConfig({ ...config, enableSubagentFallback: false });
+      mockSubagentTracker.isSubagent = vi.fn().mockReturnValue(true);
+
+      await fallbackHandler.handleRateLimitFallback('subagent-1', 'anthropic', 'claude-3-5-sonnet-20250514');
+
+      expect(mockClient.session.messages).not.toHaveBeenCalled();
+      expect(mockClient.session.abort).not.toHaveBeenCalled();
+      expect(mockClient.session.promptAsync).not.toHaveBeenCalled();
+    });
+
+    it('should stop all fallback work after enabled is hot reloaded to false', async () => {
+      fallbackHandler.updateConfig({ ...config, enabled: false });
+
+      await fallbackHandler.handleRateLimitFallback('session-1', 'anthropic', 'claude-3-5-sonnet-20250514');
+
+      expect(mockClient.session.messages).not.toHaveBeenCalled();
+      expect(mockClient.session.abort).not.toHaveBeenCalled();
     });
   });
 

--- a/__tests__/fallback/modelselector.test.ts
+++ b/__tests__/fallback/modelselector.test.ts
@@ -331,10 +331,9 @@ describe('ModelSelector', () => {
       const attemptedModels = new Set<string>();
       const nextModel = await modelSelector.selectFallbackModel('unknown', 'model', attemptedModels);
 
-      // When model is not in list, should skip to next available model
-      // Starting from index 0, and skipping current model, we get index 1
+      // A provider-specific agent model enters the configured chain at index 0.
       expect(nextModel).toBeDefined();
-      expect(nextModel?.providerID).toBe('google');
+      expect(nextModel).toEqual(config.fallbackModels[0]);
     });
 
     it('should skip model already in attempted set', async () => {

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1206,22 +1206,21 @@ describe('Subagent Support', () => {
   });
 
   it('should register subagent on session.created event', async () => {
-    // Trigger subagent.session.created event
+    // Trigger the real OpenCode child-session event shape.
     await pluginInstance.event?.({
       event: {
-        type: 'subagent.session.created',
+        type: 'session.created',
         properties: {
-          sessionID: 'subagent-session-1',
-          parentSessionID: 'root-session-1',
+          info: { id: 'subagent-session-1', parentID: 'root-session-1' },
         },
       },
     });
 
-    // Verify that the subagent's rate limit is handled at the root level
+    // Verify that the subagent's own prompt and agent are retried.
     vi.mocked(mockClient.session.messages).mockResolvedValue({
       data: [
         {
-          info: { id: 'msg1', role: 'user' },
+          info: { id: 'msg1', role: 'user', agent: 'engram' },
           parts: [{ type: 'text', text: 'test message' }],
         },
       ],
@@ -1237,12 +1236,13 @@ describe('Subagent Support', () => {
       },
     });
 
-    // Fallback should be triggered (parent-centered approach - should abort root session)
+    // Replaying the root prompt would lose the child agent and repeat unrelated work.
     expect(mockClient.session.promptAsync).toHaveBeenCalledWith(
       expect.objectContaining({
         path: expect.objectContaining({
-          id: 'root-session-1',  // Root session, not subagent session
+          id: 'subagent-session-1',
         }),
+        body: expect.objectContaining({ agent: 'engram' }),
       })
     );
   });
@@ -1251,10 +1251,9 @@ describe('Subagent Support', () => {
     // Register a subagent
     await pluginInstance.event?.({
       event: {
-        type: 'subagent.session.created',
+        type: 'session.created',
         properties: {
-          sessionID: 'subagent-session-1',
-          parentSessionID: 'root-session-1',
+          info: { id: 'subagent-session-1', parentID: 'root-session-1' },
         },
       },
     });
@@ -1262,10 +1261,9 @@ describe('Subagent Support', () => {
     // Register another subagent under the same root
     await pluginInstance.event?.({
       event: {
-        type: 'subagent.session.created',
+        type: 'session.created',
         properties: {
-          sessionID: 'subagent-session-2',
-          parentSessionID: 'root-session-1',
+          info: { id: 'subagent-session-2', parentID: 'root-session-1' },
         },
       },
     });
@@ -1290,18 +1288,16 @@ describe('Subagent Support', () => {
       },
     });
 
-    // Fallback should be triggered (on root session due to parent-centered approach)
-    expect(mockClient.session.abort).toHaveBeenCalled();
+    expect(mockClient.session.abort).toHaveBeenCalledWith({ path: { id: 'subagent-session-1' } });
   });
 
   it('should handle nested subagents', async () => {
     // Register root-level subagent
     await pluginInstance.event?.({
       event: {
-        type: 'subagent.session.created',
+        type: 'session.created',
         properties: {
-          sessionID: 'subagent-level-1',
-          parentSessionID: 'root-session-1',
+          info: { id: 'subagent-level-1', parentID: 'root-session-1' },
         },
       },
     });
@@ -1309,15 +1305,14 @@ describe('Subagent Support', () => {
     // Register nested subagent
     await pluginInstance.event?.({
       event: {
-        type: 'subagent.session.created',
+        type: 'session.created',
         properties: {
-          sessionID: 'subagent-level-2',
-          parentSessionID: 'subagent-level-1',
+          info: { id: 'subagent-level-2', parentID: 'subagent-level-1' },
         },
       },
     });
 
-    // Trigger rate limit on the deepest subagent - should propagate to root
+    // Trigger rate limit on the deepest subagent.
     vi.mocked(mockClient.session.messages).mockResolvedValue({
       data: [
         {
@@ -1337,18 +1332,16 @@ describe('Subagent Support', () => {
       },
     });
 
-    // Fallback should be triggered on root session (parent-centered approach)
-    expect(mockClient.session.abort).toHaveBeenCalled();
+    expect(mockClient.session.abort).toHaveBeenCalledWith({ path: { id: 'subagent-level-2' } });
   });
 
-  it('should trigger fallback at root level for subagent rate limits', async () => {
+  it('should trigger fallback on the failed subagent session', async () => {
     // Register a subagent
     await pluginInstance.event?.({
       event: {
-        type: 'subagent.session.created',
+        type: 'session.created',
         properties: {
-          sessionID: 'subagent-session-1',
-          parentSessionID: 'root-session-1',
+          info: { id: 'subagent-session-1', parentID: 'root-session-1' },
         },
       },
     });
@@ -1373,18 +1366,16 @@ describe('Subagent Support', () => {
       },
     });
 
-    // Fallback should be triggered
-    expect(mockClient.session.abort).toHaveBeenCalled();
+    expect(mockClient.session.abort).toHaveBeenCalledWith({ path: { id: 'subagent-session-1' } });
   });
 
-  it('should propagate model changes to subagents', async () => {
+  it('should keep a root-session fallback on the root session', async () => {
     // Register a subagent
     await pluginInstance.event?.({
       event: {
-        type: 'subagent.session.created',
+        type: 'session.created',
         properties: {
-          sessionID: 'subagent-session-1',
-          parentSessionID: 'root-session-1',
+          info: { id: 'subagent-session-1', parentID: 'root-session-1' },
         },
       },
     });
@@ -1410,9 +1401,10 @@ describe('Subagent Support', () => {
       },
     });
 
-    // Fallback should be triggered on root session
-    expect(mockClient.session.abort).toHaveBeenCalled();
-    expect(mockClient.session.promptAsync).toHaveBeenCalled();
+    expect(mockClient.session.abort).toHaveBeenCalledWith({ path: { id: 'root-session-1' } });
+    expect(mockClient.session.promptAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ path: { id: 'root-session-1' } }),
+    );
   });
 
   it('should enforce maxSubagentDepth', async () => {
@@ -1441,10 +1433,9 @@ describe('Subagent Support', () => {
     // Register first level subagent (depth 1)
     await pluginInstance.event?.({
       event: {
-        type: 'subagent.session.created',
+        type: 'session.created',
         properties: {
-          sessionID: 'subagent-level-1',
-          parentSessionID: 'root-session-1',
+          info: { id: 'subagent-level-1', parentID: 'root-session-1' },
         },
       },
     });
@@ -1452,21 +1443,19 @@ describe('Subagent Support', () => {
     // Register second level subagent (depth 2)
     await pluginInstance.event?.({
       event: {
-        type: 'subagent.session.created',
+        type: 'session.created',
         properties: {
-          sessionID: 'subagent-level-2',
-          parentSessionID: 'subagent-level-1',
+          info: { id: 'subagent-level-2', parentID: 'subagent-level-1' },
         },
       },
     });
 
-    // Register third level subagent (depth 3 - should be rejected silently)
+    // Register third level subagent (depth 3 - detailed tracking is rejected).
     await pluginInstance.event?.({
       event: {
-        type: 'subagent.session.created',
+        type: 'session.created',
         properties: {
-          sessionID: 'subagent-level-3',
-          parentSessionID: 'subagent-level-2',
+          info: { id: 'subagent-level-3', parentID: 'subagent-level-2' },
         },
       },
     });
@@ -1484,9 +1473,7 @@ describe('Subagent Support', () => {
     // Reset abort mock to clear previous calls
     vi.mocked(mockClient.session.promptAsync).mockClear();
 
-    // Try to trigger rate limit on the rejected subagent (depth 3)
-    // Since it was not registered (exceeded max depth), it's treated as a regular session
-    // Fallback should be triggered on the session itself, not on the root
+    // Minimal child classification remains, and enabled fallback stays local.
     await pluginInstance.event?.({
       event: {
         type: 'session.error',
@@ -1497,7 +1484,6 @@ describe('Subagent Support', () => {
       },
     });
 
-    // Fallback is triggered, but on the unregistered session itself
     expect(mockClient.session.promptAsync).toHaveBeenCalledWith(
       expect.objectContaining({
         path: expect.objectContaining({
@@ -1509,7 +1495,7 @@ describe('Subagent Support', () => {
     // Reset abort mock for the next test
     vi.mocked(mockClient.session.promptAsync).mockClear();
 
-    // A valid subagent (level 2) should trigger fallback on the root session
+    // A valid subagent (level 2) should be retried on its own session.
     await pluginInstance.event?.({
       event: {
         type: 'session.error',
@@ -1520,11 +1506,10 @@ describe('Subagent Support', () => {
       },
     });
 
-    // This one should trigger fallback on root (parent-centered approach)
     expect(mockClient.session.promptAsync).toHaveBeenCalledWith(
       expect.objectContaining({
         path: expect.objectContaining({
-          id: 'root-session-1',  // Root session
+          id: 'subagent-level-2',
         }),
       })
     );
@@ -1534,6 +1519,7 @@ describe('Subagent Support', () => {
 
     const mockConfig = {
       enableSubagentFallback: false,
+      maxSubagentDepth: 1,
       fallbackModels: [
         { providerID: "anthropic", modelID: "claude-3-5-sonnet-20250514" },
         { providerID: "google", modelID: "gemini-2.5-pro" },
@@ -1554,18 +1540,29 @@ describe('Subagent Support', () => {
 
     pluginInstance = result;
 
-    // Try to register a subagent (should be ignored)
+    // Child sessions are tracked even while fallback is disabled so the setting
+    // can be enforced and later hot reloaded.
     await pluginInstance.event?.({
       event: {
-        type: 'subagent.session.created',
+        type: 'session.created',
         properties: {
-          sessionID: 'subagent-session-1',
-          parentSessionID: 'root-session-1',
+          info: { id: 'subagent-session-1', parentID: 'root-session-1' },
         },
       },
     });
 
-    // Verify that subagent rate limit is NOT handled at root level (since enableSubagentFallback is false)
+    // This child exceeds detailed hierarchy tracking but must still be
+    // recognized as a child for the disable flag.
+    await pluginInstance.event?.({
+      event: {
+        type: 'session.created',
+        properties: {
+          info: { id: 'subagent-session-2', parentID: 'subagent-session-1' },
+        },
+      },
+    });
+
+    // Verify that no child fallback is attempted.
     vi.mocked(mockClient.session.messages).mockResolvedValue({
       data: [
         {
@@ -1579,30 +1576,24 @@ describe('Subagent Support', () => {
       event: {
         type: 'session.error',
         properties: {
-          sessionID: 'subagent-session-1',
+          sessionID: 'subagent-session-2',
           error: { name: "APIError", data: { statusCode: 429 } },
         },
       },
     });
 
-    // Fallback should be triggered on the subagent session itself, not the root
-    expect(mockClient.session.promptAsync).toHaveBeenCalledWith(
-      expect.objectContaining({
-        path: expect.objectContaining({
-          id: 'subagent-session-1',  // Subagent session, NOT root session
-        }),
-      })
-    );
+    expect(mockClient.session.abort).not.toHaveBeenCalled();
+    expect(mockClient.session.messages).not.toHaveBeenCalled();
+    expect(mockClient.session.promptAsync).not.toHaveBeenCalled();
   });
 
   it('should handle multiple hierarchies independently', async () => {
     // Register subagent for first hierarchy
     await pluginInstance.event?.({
       event: {
-        type: 'subagent.session.created',
+        type: 'session.created',
         properties: {
-          sessionID: 'subagent-1-1',
-          parentSessionID: 'root-1',
+          info: { id: 'subagent-1-1', parentID: 'root-1' },
         },
       },
     });
@@ -1610,10 +1601,9 @@ describe('Subagent Support', () => {
     // Register subagent for second hierarchy
     await pluginInstance.event?.({
       event: {
-        type: 'subagent.session.created',
+        type: 'session.created',
         properties: {
-          sessionID: 'subagent-2-1',
-          parentSessionID: 'root-2',
+          info: { id: 'subagent-2-1', parentID: 'root-2' },
         },
       },
     });
@@ -1675,10 +1665,9 @@ describe('Session Hierarchy Cleanup', () => {
     // Register a subagent
     await pluginInstance.event?.({
       event: {
-        type: 'subagent.session.created',
+        type: 'session.created',
         properties: {
-          sessionID: 'subagent-session-1',
-          parentSessionID: 'root-session-1',
+          info: { id: 'subagent-session-1', parentID: 'root-session-1' },
         },
       },
     });
@@ -1724,25 +1713,23 @@ describe('Session Hierarchy Cleanup', () => {
     // Register multiple subagents
     await pluginInstance.event?.({
       event: {
-        type: 'subagent.session.created',
+        type: 'session.created',
         properties: {
-          sessionID: 'subagent-session-1',
-          parentSessionID: 'root-session-1',
+          info: { id: 'subagent-session-1', parentID: 'root-session-1' },
         },
       },
     });
 
     await pluginInstance.event?.({
       event: {
-        type: 'subagent.session.created',
+        type: 'session.created',
         properties: {
-          sessionID: 'subagent-session-2',
-          parentSessionID: 'root-session-1',
+          info: { id: 'subagent-session-2', parentID: 'root-session-1' },
         },
       },
     });
 
-    // Verify that both subagents trigger fallback at root level before cleanup
+    // Verify that a tracked child is retried locally before cleanup.
     vi.mocked(mockClient.session.messages).mockResolvedValue({
       data: [
         {
@@ -1762,11 +1749,10 @@ describe('Session Hierarchy Cleanup', () => {
       },
     });
 
-    // Should trigger fallback at root
     expect(mockClient.session.promptAsync).toHaveBeenCalledWith(
       expect.objectContaining({
         path: expect.objectContaining({
-          id: 'root-session-1',
+          id: 'subagent-session-1',
         }),
       })
     );
@@ -1777,7 +1763,7 @@ describe('Session Hierarchy Cleanup', () => {
     // Cleanup should not throw errors and should clear internal state
     pluginInstance.cleanup();
 
-    // After cleanup, subagent should not trigger fallback at root level anymore
+    // After cleanup, the session is no longer classified as a tracked child.
     await pluginInstance.event?.({
       event: {
         type: 'session.error',
@@ -1864,6 +1850,98 @@ describe('Config Loading Edge Cases', () => {
   });
 });
 
+describe('Learned pattern startup hydration', () => {
+  const learnedPattern = {
+    name: 'learned-provider-capacity',
+    patterns: ['vendor-e42-capacity-signal'],
+    priority: 70,
+    confidence: 0.9,
+    learnedAt: '2026-08-12T00:00:00.000Z',
+    sampleCount: 4,
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(existsSync).mockReturnValue(true);
+  });
+
+  it('matches configured learned patterns immediately in interactive mode', async () => {
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+      fallbackModels: [{ providerID: 'google', modelID: 'gemini-fallback' }],
+      enabled: true,
+      errorPatterns: { learnedPatterns: [learnedPattern] },
+    }));
+    const client = createMockClient();
+    vi.mocked(client.session.messages).mockResolvedValue({
+      data: [{
+        info: { id: 'message-1', role: 'user' },
+        parts: [{ type: 'text', text: 'continue the task' }],
+      }],
+    });
+    const plugin = await RateLimitFallback({
+      client: client as any,
+      directory: '/test',
+      project: {} as any,
+      worktree: '/test',
+      serverUrl: new URL('http://test.com'),
+      $: {} as any,
+    });
+
+    await plugin.event?.({
+      event: {
+        type: 'session.error',
+        properties: {
+          sessionID: 'learned-session',
+          error: { message: 'vendor-e42-capacity-signal' },
+        },
+      },
+    });
+
+    expect(client.session.abort).toHaveBeenCalledWith({
+      path: { id: 'learned-session' },
+    });
+    expect(client.session.promptAsync).toHaveBeenCalledWith(expect.objectContaining({
+      path: { id: 'learned-session' },
+      body: expect.objectContaining({
+        model: { providerID: 'google', modelID: 'gemini-fallback' },
+      }),
+    }));
+    plugin.cleanup?.();
+  });
+
+  it('matches configured learned patterns immediately in headless abort mode', async () => {
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+      enabled: true,
+      headlessOnRateLimit: 'abort',
+      errorPatterns: { learnedPatterns: [learnedPattern] },
+    }));
+    const client = createMockClient() as any;
+    delete client.tui;
+    const plugin = await RateLimitFallback({
+      client,
+      directory: '/test',
+      project: {} as any,
+      worktree: '/test',
+      serverUrl: new URL('http://test.com'),
+      $: {} as any,
+    });
+
+    await plugin.event?.({
+      event: {
+        type: 'session.error',
+        properties: {
+          sessionID: 'headless-learned-session',
+          error: { message: 'vendor-e42-capacity-signal' },
+        },
+      },
+    });
+
+    expect(client.session.abort).toHaveBeenCalledWith({
+      path: { id: 'headless-learned-session' },
+    });
+  });
+});
+
 describe('Cleanup Functionality', () => {
   let mockClient: ReturnType<typeof createMockClient>;
   let pluginInstance: any;
@@ -1898,10 +1976,9 @@ describe('Cleanup Functionality', () => {
     // Register a subagent to populate sessionHierarchies
     await pluginInstance.event?.({
       event: {
-        type: 'subagent.session.created',
+        type: 'session.created',
         properties: {
-          sessionID: 'subagent-1',
-          parentSessionID: 'root-1',
+          info: { id: 'subagent-1', parentID: 'root-1' },
         },
       },
     });
@@ -1926,11 +2003,10 @@ describe('Cleanup Functionality', () => {
       },
     });
 
-    // Should trigger fallback at root
     expect(mockClient.session.promptAsync).toHaveBeenCalledWith(
       expect.objectContaining({
         path: expect.objectContaining({
-          id: 'root-1',
+          id: 'subagent-1',
         }),
       })
     );

--- a/__tests__/main/configreloader.test.ts
+++ b/__tests__/main/configreloader.test.ts
@@ -49,6 +49,7 @@ describe('ConfigReloader', () => {
       },
       errorPatternRegistry: {
         registerIgnorePatterns: vi.fn(),
+        replaceCustomPatterns: vi.fn(),
         updateLearnedPatterns: vi.fn(),
         configurePatternLearning: vi.fn(),
       },
@@ -147,6 +148,36 @@ describe('ConfigReloader', () => {
       });
     });
 
+    it('should hot reload fallback models and subagent settings', async () => {
+      const fallbackModels = [{ providerID: 'google', modelID: 'gemini-fallback' }];
+      writeFileSync(configPath, JSON.stringify({
+        ...config,
+        fallbackModels,
+        enableSubagentFallback: false,
+        maxSubagentDepth: 3,
+      }));
+
+      const reloader = new ConfigReloader(
+        config,
+        configPath,
+        mockLogger,
+        mockValidator,
+        mockClient,
+        mockComponents,
+        testDir
+      );
+
+      await reloader.reloadConfig();
+
+      expect(mockComponents.fallbackHandler.updateConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fallbackModels,
+          enableSubagentFallback: false,
+          maxSubagentDepth: 3,
+        }),
+      );
+    });
+
     it('should hot reload ignore patterns, including an explicit empty list', async () => {
       writeFileSync(configPath, JSON.stringify({
         ...config,
@@ -180,6 +211,46 @@ describe('ConfigReloader', () => {
         .toHaveBeenLastCalledWith([]);
     });
 
+    it('should replace custom error patterns, including removals', async () => {
+      const custom = [{
+        name: 'provider-capacity',
+        patterns: ['capacity exhausted'],
+        priority: 95,
+      }];
+      writeFileSync(configPath, JSON.stringify({
+        ...config,
+        errorPatterns: { custom },
+      }));
+
+      const reloader = new ConfigReloader(
+        config,
+        configPath,
+        mockLogger,
+        mockValidator,
+        mockClient,
+        mockComponents,
+        testDir,
+        undefined,
+        false,
+        0
+      );
+
+      await reloader.reloadConfig();
+      expect(mockComponents.errorPatternRegistry.replaceCustomPatterns)
+        .toHaveBeenLastCalledWith(custom);
+
+      writeFileSync(configPath, JSON.stringify({
+        ...config,
+        errorPatterns: { custom: [] },
+      }));
+      await reloader.reloadConfig();
+
+      expect(mockComponents.errorPatternRegistry.replaceCustomPatterns)
+        .toHaveBeenLastCalledWith([]);
+      expect(mockComponents.errorPatternRegistry.updateLearnedPatterns)
+        .toHaveBeenLastCalledWith([]);
+    });
+
     it('should hot reload pattern learning with default values and the config source', async () => {
       writeFileSync(configPath, JSON.stringify({
         ...config,
@@ -205,6 +276,103 @@ describe('ConfigReloader', () => {
         minErrorFrequency: 7,
         learningWindowMs: 86400000,
       }, configPath);
+    });
+
+    it('should sanitize malformed patterns in non-strict mode before applying them', async () => {
+      writeFileSync(configPath, JSON.stringify({
+        ...config,
+        errorPatterns: {
+          custom: [null, {}],
+          learnedPatterns: [null, {}],
+        },
+      }));
+      const reloader = new ConfigReloader(
+        config,
+        configPath,
+        mockLogger,
+        new ConfigValidator(mockLogger),
+        mockClient,
+        mockComponents,
+        testDir,
+        undefined,
+        false,
+        0
+      );
+
+      const result = await reloader.reloadConfig();
+
+      expect(result.success).toBe(true);
+      expect(mockComponents.errorPatternRegistry.replaceCustomPatterns).toHaveBeenCalledWith([]);
+      expect(mockComponents.errorPatternRegistry.updateLearnedPatterns).toHaveBeenCalledWith([]);
+      expect(mockComponents.fallbackHandler.updateConfig).toHaveBeenCalled();
+    });
+
+    it('should reject malformed patterns in strict mode without partial component updates', async () => {
+      writeFileSync(configPath, JSON.stringify({
+        ...config,
+        configValidation: { strict: true },
+        errorPatterns: {
+          custom: [null],
+          learnedPatterns: [{}],
+        },
+      }));
+      const reloader = new ConfigReloader(
+        config,
+        configPath,
+        mockLogger,
+        new ConfigValidator(mockLogger),
+        mockClient,
+        mockComponents,
+        testDir,
+        undefined,
+        false,
+        0
+      );
+
+      const result = await reloader.reloadConfig();
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('errorPatterns.custom[0]');
+      expect(mockComponents.errorPatternRegistry.replaceCustomPatterns).not.toHaveBeenCalled();
+      expect(mockComponents.fallbackHandler.updateConfig).not.toHaveBeenCalled();
+      expect(mockComponents.metricsManager.updateConfig).not.toHaveBeenCalled();
+      expect(reloader.getCurrentConfig()).toEqual(config);
+    });
+
+    it('should not update fallback components when pattern application fails', async () => {
+      const custom = [{
+        name: 'provider-capacity',
+        patterns: ['capacity exhausted'],
+        priority: 95,
+      }];
+      writeFileSync(configPath, JSON.stringify({
+        ...config,
+        errorPatterns: { custom },
+      }));
+      mockComponents.errorPatternRegistry.replaceCustomPatterns.mockImplementation(() => {
+        throw new Error('pattern registry failed');
+      });
+      const reloader = new ConfigReloader(
+        config,
+        configPath,
+        mockLogger,
+        new ConfigValidator(mockLogger),
+        mockClient,
+        mockComponents,
+        testDir,
+        undefined,
+        false,
+        0
+      );
+
+      const result = await reloader.reloadConfig();
+
+      expect(result.success).toBe(false);
+      expect(mockComponents.errorPatternRegistry.registerIgnorePatterns).not.toHaveBeenCalled();
+      expect(mockComponents.errorPatternRegistry.updateLearnedPatterns).not.toHaveBeenCalled();
+      expect(mockComponents.fallbackHandler.updateConfig).not.toHaveBeenCalled();
+      expect(mockComponents.metricsManager.updateConfig).not.toHaveBeenCalled();
+      expect(reloader.getCurrentConfig()).toEqual(config);
     });
 
     it('should track successful reload metrics', async () => {

--- a/__tests__/patternregistry.test.ts
+++ b/__tests__/patternregistry.test.ts
@@ -389,6 +389,68 @@ describe('ErrorPatternRegistry', () => {
     });
   });
 
+  describe('replaceCustomPatterns()', () => {
+    it('removes stale file-configured patterns on reload', () => {
+      registry.replaceCustomPatterns([
+        { name: 'provider-capacity', patterns: ['capacity exhausted'], priority: 95 },
+      ]);
+      expect(registry.isRateLimitError({ message: 'capacity exhausted' })).toBe(true);
+
+      registry.replaceCustomPatterns([]);
+
+      expect(registry.getPatternByName('provider-capacity')).toBeUndefined();
+      expect(registry.isRateLimitError({ message: 'capacity exhausted' })).toBe(false);
+    });
+
+    it('restores a built-in pattern after an overriding custom pattern is removed', () => {
+      const builtIn = registry.getPatternByName('http-429');
+      registry.replaceCustomPatterns([
+        { name: 'http-429', patterns: ['custom throttle'], priority: 100 },
+      ]);
+      expect(registry.getPatternByName('http-429')?.patterns).toEqual(['custom throttle']);
+
+      registry.replaceCustomPatterns([]);
+
+      expect(registry.getPatternByName('http-429')).toEqual(builtIn);
+      expect(registry.isRateLimitError({ name: 'APIError', data: { statusCode: 429 } })).toBe(true);
+    });
+
+    it('uses the last duplicate custom definition and still restores the built-in', () => {
+      const builtIn = registry.getPatternByName('http-429');
+      registry.replaceCustomPatterns([
+        { name: 'http-429', patterns: ['first override'], priority: 99 },
+        { name: 'http-429', patterns: ['last override'], priority: 100 },
+      ]);
+
+      expect(registry.getPatternByName('http-429')?.patterns).toEqual(['last override']);
+      registry.replaceCustomPatterns([]);
+      expect(registry.getPatternByName('http-429')).toEqual(builtIn);
+    });
+
+    it('ignores malformed custom entries defensively', () => {
+      expect(() => registry.replaceCustomPatterns([null, {}] as any)).not.toThrow();
+      expect(registry.isRateLimitError({ message: 'unrelated provider failure' })).toBe(false);
+    });
+  });
+
+  describe('updateLearnedPatterns()', () => {
+    it('keeps only valid learned entries defensively', () => {
+      const valid = {
+        name: 'learned-capacity',
+        patterns: ['learned capacity signal'],
+        priority: 70,
+        confidence: 0.9,
+        learnedAt: '2026-08-12T00:00:00.000Z',
+        sampleCount: 4,
+      };
+
+      registry.updateLearnedPatterns([null, {}, valid] as any);
+
+      expect(registry.getLearnedPatterns()).toEqual([valid]);
+      expect(registry.isRateLimitError({ message: 'learned capacity signal' })).toBe(true);
+    });
+  });
+
   describe('removePattern()', () => {
     it('should remove a pattern by name', () => {
       registry.register({

--- a/__tests__/subagenttracker.test.ts
+++ b/__tests__/subagenttracker.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { SubagentTracker } from '../src/session/SubagentTracker.js';
+import type { PluginConfig } from '../src/types/index.js';
+
+const config = (maxSubagentDepth = 10): PluginConfig => ({
+  fallbackModels: [],
+  cooldownMs: 60_000,
+  enabled: true,
+  fallbackMode: 'cycle',
+  maxSubagentDepth,
+});
+
+describe('SubagentTracker', () => {
+  it('tracks the parent and root for a child session', () => {
+    const tracker = new SubagentTracker(config());
+
+    expect(tracker.registerSubagent('child-1', 'root-1')).toBe(true);
+    expect(tracker.isSubagent('child-1')).toBe(true);
+    expect(tracker.isSubagent('root-1')).toBe(false);
+    expect(tracker.getRootSession('child-1')).toBe('root-1');
+    expect(tracker.getHierarchy('child-1')?.subagents.get('child-1')).toMatchObject({
+      parentSessionID: 'root-1',
+      depth: 1,
+    });
+  });
+
+  it('tracks nested child sessions without reclassifying the root', () => {
+    const tracker = new SubagentTracker(config());
+
+    tracker.registerSubagent('child-1', 'root-1');
+    tracker.registerSubagent('child-2', 'child-1');
+
+    expect(tracker.getRootSession('child-2')).toBe('root-1');
+    expect(tracker.getHierarchy('child-2')?.subagents.get('child-2')?.depth).toBe(2);
+  });
+
+  it('applies a hot-reloaded maximum depth to future sessions', () => {
+    const tracker = new SubagentTracker(config(1));
+
+    tracker.registerSubagent('child-1', 'root-1');
+    expect(tracker.registerSubagent('child-2', 'child-1')).toBe(false);
+    expect(tracker.isSubagent('child-2')).toBe(true);
+    expect(tracker.getRootSession('child-2')).toBe('root-1');
+
+    tracker.updateConfig(config(2));
+    expect(tracker.registerSubagent('child-2', 'child-1')).toBe(true);
+    expect(tracker.getHierarchy('child-2')?.subagents.get('child-2')?.depth).toBe(2);
+  });
+
+  it('clears child classification with the hierarchy', () => {
+    const tracker = new SubagentTracker(config());
+    tracker.registerSubagent('child-1', 'root-1');
+
+    tracker.clearAll();
+
+    expect(tracker.isSubagent('child-1')).toBe(false);
+    expect(tracker.getRootSession('child-1')).toBeNull();
+    expect(tracker.getHierarchy('child-1')).toBeNull();
+  });
+});

--- a/__tests__/validator.test.ts
+++ b/__tests__/validator.test.ts
@@ -106,6 +106,19 @@ describe('ConfigValidator', () => {
       expect(result.errors.some(e => e.path.includes('cooldownMs'))).toBe(true);
     });
 
+    it('should reject invalid subagent settings', () => {
+      const result = validator.validate({
+        fallbackModels: [],
+        enableSubagentFallback: 'yes' as unknown as boolean,
+        maxSubagentDepth: 1.5,
+      });
+
+      expect(result.errors).toEqual(expect.arrayContaining([
+        expect.objectContaining({ path: 'enableSubagentFallback' }),
+        expect.objectContaining({ path: 'maxSubagentDepth' }),
+      ]));
+    });
+
     it('should apply default values for optional properties', () => {
       const minimalConfig = {
         fallbackModels: [{ providerID: 'anthropic', modelID: 'claude-3-5-sonnet-20250514' }],
@@ -392,9 +405,7 @@ describe('ConfigValidator', () => {
       expect(result.errors.some(e => e.path === 'errorPatterns.ignorePatterns')).toBe(true);
     });
 
-    // Skip custom error pattern tests - Validator doesn't validate individual custom entries yet
-    // These tests can be re-enabled when custom pattern validation is implemented
-    it.skip('should reject error pattern with empty name (strict mode)', () => {
+    it('should reject error pattern with empty name (strict mode)', () => {
       const config = {
         fallbackModels: [{ providerID: 'anthropic', modelID: 'claude-3-5-sonnet-20250514' }],
         cooldownMs: 5000,
@@ -417,7 +428,7 @@ describe('ConfigValidator', () => {
       expect(result.errors.some(e => e.path.includes('errorPatterns.custom'))).toBe(true);
     });
 
-    it.skip('should reject error pattern with empty patterns array (strict mode)', () => {
+    it('should reject error pattern with empty patterns array (strict mode)', () => {
       const config = {
         fallbackModels: [{ providerID: 'anthropic', modelID: 'claude-3-5-sonnet-20250514' }],
         cooldownMs: 5000,
@@ -440,7 +451,7 @@ describe('ConfigValidator', () => {
       expect(result.errors.some(e => e.path.includes('errorPatterns.custom'))).toBe(true);
     });
 
-    it.skip('should reject error pattern with invalid priority (strict mode)', () => {
+    it('should reject error pattern with invalid priority (strict mode)', () => {
       const config = {
         fallbackModels: [{ providerID: 'anthropic', modelID: 'claude-3-5-sonnet-20250514' }],
         cooldownMs: 5000,
@@ -451,7 +462,7 @@ describe('ConfigValidator', () => {
             {
               name: 'pattern-name',
               patterns: ['pattern'],
-              priority: 150,
+              priority: -1,
             },
           ],
         },
@@ -461,6 +472,37 @@ describe('ConfigValidator', () => {
 
       expect(result.isValid).toBe(false);
       expect(result.errors.some(e => e.path.includes('errorPatterns.custom'))).toBe(true);
+    });
+
+    it('should reject malformed custom and learned pattern entries (strict mode)', () => {
+      const config = {
+        fallbackModels: [{ providerID: 'anthropic', modelID: 'claude-3-5-sonnet-20250514' }],
+        cooldownMs: 5000,
+        enabled: true,
+        fallbackMode: 'cycle' as const,
+        errorPatterns: {
+          custom: [null, {}],
+          learnedPatterns: [{
+            name: 'learned-pattern',
+            patterns: ['learned signal'],
+            priority: 50,
+            confidence: 2,
+            learnedAt: 'not-a-date',
+            sampleCount: 0,
+          }],
+        },
+      };
+
+      const result = validator.validate(config as any, { strict: true });
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors.map(e => e.path)).toEqual(expect.arrayContaining([
+        'errorPatterns.custom[0]',
+        'errorPatterns.custom[1].patterns',
+        'errorPatterns.learnedPatterns[0].confidence',
+        'errorPatterns.learnedPatterns[0].learnedAt',
+        'errorPatterns.learnedPatterns[0].sampleCount',
+      ]));
     });
   });
 

--- a/index.ts
+++ b/index.ts
@@ -10,6 +10,7 @@ import { createLogger, type LogSink } from "./logger.js";
 // Import modular components
 import type {
   MessageUpdatedEventProperties,
+  SessionCreatedEventProperties,
   SessionErrorEventProperties,
   SessionStatusEventProperties,
 } from "./src/types/index.js";
@@ -92,14 +93,19 @@ function isSessionStatusEvent(event: { type: string; properties: unknown }): eve
 }
 
 /**
- * Check if event is a subagent session created event
+ * Check if event is a session creation event
  */
-function isSubagentSessionCreatedEvent(event: { type: string; properties?: unknown }): event is { type: "subagent.session.created"; properties: { sessionID: string; parentSessionID: string; [key: string]: unknown } } {
-  return event.type === "subagent.session.created" &&
+function isSessionCreatedEvent(event: { type: string; properties?: unknown }): event is { type: "session.created"; properties: SessionCreatedEventProperties } {
+  if (event.type === "session.created" &&
     typeof event.properties === "object" &&
-    event.properties !== null &&
-    "sessionID" in event.properties &&
-    "parentSessionID" in event.properties;
+    event.properties !== null) {
+    const info = "info" in event.properties ? event.properties.info : undefined;
+    if (typeof info !== "object" || info === null || !("id" in info) || typeof info.id !== "string") {
+      return false;
+    }
+    return !("parentID" in info) || info.parentID === undefined || typeof info.parentID === "string";
+  }
+  return false;
 }
 
 // ============================================================================
@@ -215,7 +221,10 @@ export const RateLimitFallback: Plugin = async ({ client, directory, worktree })
       // Minimal setup: only error pattern detection + abort
       const errorPatternRegistry = new ErrorPatternRegistry(logger, config.errorPatterns?.ignorePatterns);
       if (config.errorPatterns?.custom) {
-        errorPatternRegistry.registerMany(config.errorPatterns.custom);
+        errorPatternRegistry.replaceCustomPatterns(config.errorPatterns.custom);
+      }
+      if (config.errorPatterns?.learnedPatterns) {
+        errorPatternRegistry.updateLearnedPatterns(config.errorPatterns.learnedPatterns);
       }
 
       // Track sessions already aborted to avoid duplicate abort calls
@@ -270,7 +279,10 @@ export const RateLimitFallback: Plugin = async ({ client, directory, worktree })
   // Initialize error pattern registry
   const errorPatternRegistry = new ErrorPatternRegistry(logger, config.errorPatterns?.ignorePatterns);
   if (config.errorPatterns?.custom) {
-    errorPatternRegistry.registerMany(config.errorPatterns.custom);
+    errorPatternRegistry.replaceCustomPatterns(config.errorPatterns.custom);
+  }
+  if (config.errorPatterns?.learnedPatterns) {
+    errorPatternRegistry.updateLearnedPatterns(config.errorPatterns.learnedPatterns);
   }
 
   // Initialize pattern learning if enabled
@@ -425,12 +437,15 @@ export const RateLimitFallback: Plugin = async ({ client, directory, worktree })
         }
       }
 
-      // Handle subagent session creation events
+      // OpenCode represents subagents as regular child sessions.
       const rawEvent = event as { type: string; properties?: unknown };
-      if (isSubagentSessionCreatedEvent(rawEvent)) {
-        const { sessionID, parentSessionID } = rawEvent.properties;
-        if (config.enableSubagentFallback !== false) {
-          subagentTracker.registerSubagent(sessionID, parentSessionID);
+      if (isSessionCreatedEvent(rawEvent)) {
+        const { id, parentID } = rawEvent.properties.info;
+        if (parentID && !subagentTracker.registerSubagent(id, parentID)) {
+          logger.warn("Subagent session exceeds configured tracking depth", {
+            sessionID: id,
+            parentSessionID: parentID,
+          });
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azumag/opencode-rate-limit-fallback",
-  "version": "1.70.7",
+  "version": "1.70.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azumag/opencode-rate-limit-fallback",
-      "version": "1.70.7",
+      "version": "1.70.8",
       "license": "MIT",
       "dependencies": {
         "@opencode-ai/plugin": "1.18.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azumag/opencode-rate-limit-fallback",
-  "version": "1.70.7",
+  "version": "1.70.8",
   "description": "OpenCode plugin that automatically switches to fallback models when rate limited",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/config/Validator.ts
+++ b/src/config/Validator.ts
@@ -4,6 +4,10 @@
 
 import type { PluginConfig } from '../types/index.js';
 import { existsSync, readFileSync } from 'fs';
+import {
+  getErrorPatternValidationIssues,
+  getLearnedPatternValidationIssues,
+} from './patternValidation.js';
 
 /**
  * Validation error details
@@ -146,6 +150,25 @@ export class ConfigValidator {
         message: 'enabled must be a boolean',
         severity: 'error',
         value: config.enabled,
+      });
+    }
+
+    if (config.enableSubagentFallback !== undefined && typeof config.enableSubagentFallback !== 'boolean') {
+      errors.push({
+        path: 'enableSubagentFallback',
+        message: 'enableSubagentFallback must be a boolean',
+        severity: 'error',
+        value: config.enableSubagentFallback,
+      });
+    }
+
+    if (config.maxSubagentDepth !== undefined &&
+      (!Number.isInteger(config.maxSubagentDepth) || config.maxSubagentDepth < 1)) {
+      errors.push({
+        path: 'maxSubagentDepth',
+        message: 'maxSubagentDepth must be a positive integer',
+        severity: 'error',
+        value: config.maxSubagentDepth,
       });
     }
 
@@ -509,13 +532,48 @@ export class ConfigValidator {
           value: config.errorPatterns,
         });
       } else {
-        if (config.errorPatterns.custom && !Array.isArray(config.errorPatterns.custom)) {
-          errors.push({
-            path: 'errorPatterns.custom',
-            message: 'custom must be an array',
-            severity: 'error',
-            value: config.errorPatterns.custom,
-          });
+        if (config.errorPatterns.custom !== undefined) {
+          if (!Array.isArray(config.errorPatterns.custom)) {
+            errors.push({
+              path: 'errorPatterns.custom',
+              message: 'custom must be an array',
+              severity: 'error',
+              value: config.errorPatterns.custom,
+            });
+          } else {
+            config.errorPatterns.custom.forEach((pattern, index) => {
+              for (const issue of getErrorPatternValidationIssues(pattern)) {
+                errors.push({
+                  path: `errorPatterns.custom[${index}]${issue.path ? `.${issue.path}` : ''}`,
+                  message: issue.message,
+                  severity: 'error',
+                  value: pattern,
+                });
+              }
+            });
+          }
+        }
+
+        if (config.errorPatterns.learnedPatterns !== undefined) {
+          if (!Array.isArray(config.errorPatterns.learnedPatterns)) {
+            errors.push({
+              path: 'errorPatterns.learnedPatterns',
+              message: 'learnedPatterns must be an array',
+              severity: 'error',
+              value: config.errorPatterns.learnedPatterns,
+            });
+          } else {
+            config.errorPatterns.learnedPatterns.forEach((pattern, index) => {
+              for (const issue of getLearnedPatternValidationIssues(pattern)) {
+                errors.push({
+                  path: `errorPatterns.learnedPatterns[${index}]${issue.path ? `.${issue.path}` : ''}`,
+                  message: issue.message,
+                  severity: 'error',
+                  value: pattern,
+                });
+              }
+            });
+          }
         }
 
         if (config.errorPatterns.ignorePatterns !== undefined) {

--- a/src/config/patternValidation.ts
+++ b/src/config/patternValidation.ts
@@ -1,0 +1,85 @@
+import type { ErrorPattern, LearnedPattern } from '../types/index.js';
+
+export interface PatternValidationIssue {
+  path: string;
+  message: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isValidPatternValue(value: unknown): value is string | RegExp {
+  return (typeof value === 'string' && value.trim().length > 0) || value instanceof RegExp;
+}
+
+export function getErrorPatternValidationIssues(value: unknown): PatternValidationIssue[] {
+  if (!isRecord(value)) {
+    return [{ path: '', message: 'pattern must be an object' }];
+  }
+
+  const issues: PatternValidationIssue[] = [];
+
+  if (typeof value.name !== 'string' || value.name.trim().length === 0) {
+    issues.push({ path: 'name', message: 'name must be a non-empty string' });
+  }
+
+  if (value.provider !== undefined &&
+      (typeof value.provider !== 'string' || value.provider.trim().length === 0)) {
+    issues.push({ path: 'provider', message: 'provider must be a non-empty string' });
+  }
+
+  if (!Array.isArray(value.patterns)) {
+    issues.push({ path: 'patterns', message: 'patterns must be an array' });
+  } else if (value.patterns.length === 0) {
+    issues.push({ path: 'patterns', message: 'patterns must contain at least one entry' });
+  } else {
+    value.patterns.forEach((pattern, index) => {
+      if (!isValidPatternValue(pattern)) {
+        issues.push({
+          path: `patterns[${index}]`,
+          message: 'pattern must be a non-empty string or RegExp',
+        });
+      }
+    });
+  }
+
+  if (typeof value.priority !== 'number' || !Number.isFinite(value.priority) ||
+      value.priority < 0) {
+    issues.push({ path: 'priority', message: 'priority must be a non-negative finite number' });
+  }
+
+  return issues;
+}
+
+export function getLearnedPatternValidationIssues(value: unknown): PatternValidationIssue[] {
+  const issues = getErrorPatternValidationIssues(value);
+  if (!isRecord(value)) {
+    return issues;
+  }
+
+  if (typeof value.confidence !== 'number' || !Number.isFinite(value.confidence) ||
+      value.confidence < 0 || value.confidence > 1) {
+    issues.push({ path: 'confidence', message: 'confidence must be a number between 0 and 1' });
+  }
+
+  if (typeof value.learnedAt !== 'string' || value.learnedAt.trim().length === 0 ||
+      Number.isNaN(Date.parse(value.learnedAt))) {
+    issues.push({ path: 'learnedAt', message: 'learnedAt must be a valid date string' });
+  }
+
+  if (typeof value.sampleCount !== 'number' || !Number.isInteger(value.sampleCount) ||
+      value.sampleCount < 1) {
+    issues.push({ path: 'sampleCount', message: 'sampleCount must be a positive integer' });
+  }
+
+  return issues;
+}
+
+export function isValidErrorPattern(value: unknown): value is ErrorPattern {
+  return getErrorPatternValidationIssues(value).length === 0;
+}
+
+export function isValidLearnedPattern(value: unknown): value is LearnedPattern {
+  return getLearnedPatternValidationIssues(value).length === 0;
+}

--- a/src/errors/PatternRegistry.ts
+++ b/src/errors/PatternRegistry.ts
@@ -5,6 +5,7 @@
 import type { ErrorPattern, LearnedPattern, PatternLearningConfig } from '../types/index.js';
 import type { Logger } from '../../logger.js';
 import { DEFAULT_ERROR_PATTERNS_CONFIG } from '../config/defaults.js';
+import { isValidErrorPattern, isValidLearnedPattern } from '../config/patternValidation.js';
 import { PatternLearner } from './PatternLearner.js';
 
 export type ErrorClassification = 'rate-limit' | 'ignored' | 'other';
@@ -17,6 +18,8 @@ export class ErrorPatternRegistry {
   private patterns: ErrorPattern[] = [];
   private ignorePatterns: (string | RegExp)[] = [];
   private learnedPatterns: LearnedPattern[] = [];
+  private customPatternNames = new Set<string>();
+  private overriddenPatterns = new Map<string, ErrorPattern>();
   private patternLearner: PatternLearner | null = null;
   private learningConfig: PatternLearningConfig | null = null;
   // Logger is available for future use
@@ -114,6 +117,11 @@ export class ErrorPatternRegistry {
    * Register a new error pattern
    */
   register(pattern: ErrorPattern): void {
+    if (!isValidErrorPattern(pattern)) {
+      this._logger.warn('Ignoring invalid error pattern');
+      return;
+    }
+
     // Check for duplicate names
     const existingIndex = this.patterns.findIndex(p => p.name === pattern.name);
     if (existingIndex >= 0) {
@@ -133,6 +141,40 @@ export class ErrorPatternRegistry {
     for (const pattern of patterns) {
       this.register(pattern);
     }
+  }
+
+  /**
+   * Replace file-configured patterns so removals take effect during hot reload.
+   */
+  replaceCustomPatterns(patterns: readonly ErrorPattern[]): void {
+    const validPatterns = Array.isArray(patterns)
+      ? patterns.filter(isValidErrorPattern)
+      : [];
+    const nextPatterns = this.patterns.filter(pattern => !this.customPatternNames.has(pattern.name));
+    for (const overridden of this.overriddenPatterns.values()) {
+      nextPatterns.push(overridden);
+    }
+    const nextCustomPatternNames = new Set<string>();
+    const nextOverriddenPatterns = new Map<string, ErrorPattern>();
+
+    // Build the complete next state before replacing the live registry.
+    for (const pattern of validPatterns) {
+      const existingIndex = nextPatterns.findIndex(candidate => candidate.name === pattern.name);
+      if (existingIndex >= 0 && !nextCustomPatternNames.has(pattern.name)) {
+        nextOverriddenPatterns.set(pattern.name, nextPatterns[existingIndex]);
+      }
+      if (existingIndex >= 0) {
+        nextPatterns[existingIndex] = pattern;
+      } else {
+        nextPatterns.push(pattern);
+      }
+      nextCustomPatternNames.add(pattern.name);
+    }
+
+    nextPatterns.sort((a, b) => b.priority - a.priority);
+    this.patterns = nextPatterns;
+    this.customPatternNames = nextCustomPatternNames;
+    this.overriddenPatterns = nextOverriddenPatterns;
   }
 
   registerIgnorePatterns(patterns: readonly (string | RegExp)[] | null | undefined): void {
@@ -188,6 +230,11 @@ export class ErrorPatternRegistry {
    * Add a learned pattern
    */
   addLearnedPattern(pattern: LearnedPattern): void {
+    if (!isValidLearnedPattern(pattern)) {
+      this._logger.warn('Ignoring invalid learned pattern');
+      return;
+    }
+
     // Check for duplicates by name
     const existingIndex = this.learnedPatterns.findIndex(p => p.name === pattern.name);
     if (existingIndex >= 0) {
@@ -215,7 +262,9 @@ export class ErrorPatternRegistry {
    * Update learned patterns
    */
   updateLearnedPatterns(patterns: LearnedPattern[]): void {
-    this.learnedPatterns = [...patterns];
+    this.learnedPatterns = Array.isArray(patterns)
+      ? patterns.filter(isValidLearnedPattern)
+      : [];
   }
 
   /**
@@ -328,6 +377,8 @@ export class ErrorPatternRegistry {
    */
   clearAllPatterns(): void {
     this.patterns = [];
+    this.customPatternNames.clear();
+    this.overriddenPatterns.clear();
   }
 
   /**

--- a/src/fallback/FallbackHandler.ts
+++ b/src/fallback/FallbackHandler.ts
@@ -148,19 +148,14 @@ export class FallbackHandler {
       lastUpdated: Date.now(),
     });
 
-    // If this is a root session with subagents, propagate model to all subagents
+    // Update hierarchy state for the session that was actually retried.
     if (hierarchy) {
       if (hierarchy.rootSessionID === targetSessionID) {
         hierarchy.sharedFallbackState = "completed";
         hierarchy.lastActivity = Date.now();
-
-        // Update model tracking for all subagents
-        for (const [subagentID, subagent] of hierarchy.subagents.entries()) {
-          this.currentSessionModel.set(subagentID, {
-            providerID: model.providerID,
-            modelID: model.modelID,
-            lastUpdated: Date.now(),
-          });
+      } else {
+        const subagent = hierarchy.subagents.get(targetSessionID);
+        if (subagent) {
           subagent.fallbackState = "completed";
           subagent.lastActivity = Date.now();
         }
@@ -213,9 +208,19 @@ export class FallbackHandler {
    * Handle the rate limit fallback process
    */
   async handleRateLimitFallback(sessionID: string, currentProviderID: string, currentModelID: string): Promise<void> {
-    // Resolve target session before acquiring lock
-    const rootSessionID = this.subagentTracker.getRootSession(sessionID);
-    const targetSessionID = rootSessionID || sessionID;
+    if (!this.config.enabled) {
+      return;
+    }
+
+    const isSubagent = this.subagentTracker.isSubagent(sessionID);
+    if (isSubagent && this.config.enableSubagentFallback === false) {
+      this.logger.info("Subagent fallback is disabled", { sessionID });
+      return;
+    }
+
+    // Retry the failed session itself. Replaying the root prompt would run a
+    // different agent and does not change a child agent's configured model.
+    const targetSessionID = sessionID;
 
     // Session-level lock: prevent concurrent fallback processing
     if (this.sessionLock.has(targetSessionID)) {
@@ -225,7 +230,7 @@ export class FallbackHandler {
     this.sessionLock.add(targetSessionID);
 
     try {
-      const hierarchy = this.subagentTracker.getHierarchy(sessionID);
+      const hierarchy = this.subagentTracker.getHierarchy(targetSessionID);
 
       // If no model info provided, try to get from tracked session model
       if (!currentProviderID || !currentModelID) {
@@ -268,25 +273,28 @@ export class FallbackHandler {
       }
 
       // Check deduplication with message scope
-      const dedupSessionID = rootSessionID || sessionID;
+      const dedupSessionID = targetSessionID;
       if (!this.checkAndMarkFallbackInProgress(dedupSessionID, lastUserMessage.info.id)) {
         return; // Skip - already processing
       }
 
       // Update hierarchy state if exists
-      if (hierarchy && rootSessionID) {
-        hierarchy.sharedFallbackState = "in_progress";
+      if (hierarchy) {
         hierarchy.lastActivity = Date.now();
-        const subagent = hierarchy.subagents.get(sessionID);
-        if (subagent) {
-          subagent.fallbackState = "in_progress";
-          subagent.lastActivity = Date.now();
+        if (hierarchy.rootSessionID === targetSessionID) {
+          hierarchy.sharedFallbackState = "in_progress";
+        } else {
+          const subagent = hierarchy.subagents.get(targetSessionID);
+          if (subagent) {
+            subagent.fallbackState = "in_progress";
+            subagent.lastActivity = Date.now();
+          }
         }
       }
 
       // Get or create retry state for this message
-      const state = this.getOrCreateRetryState(sessionID, lastUserMessage.info.id);
-      const stateKey = getStateKey(sessionID, lastUserMessage.info.id);
+      const state = this.getOrCreateRetryState(targetSessionID, lastUserMessage.info.id);
+      const stateKey = getStateKey(targetSessionID, lastUserMessage.info.id);
       const fallbackKey = getStateKey(dedupSessionID, lastUserMessage.info.id);
 
       // Check if retry should be attempted (using retry manager)
@@ -553,6 +561,7 @@ export class FallbackHandler {
    */
   updateConfig(newConfig: PluginConfig): void {
     this.config = newConfig;
+    this.subagentTracker.updateConfig(newConfig);
 
     // Update model selector
     this.modelSelector.updateConfig(newConfig);

--- a/src/fallback/ModelSelector.ts
+++ b/src/fallback/ModelSelector.ts
@@ -68,8 +68,8 @@ export class ModelSelector {
     const currentKey = getModelKey(currentProviderID, currentModelID);
     const startIndex = this.config.fallbackModels.findIndex(m => getModelKey(m.providerID, m.modelID) === currentKey);
 
-    // If current model is not in the fallback list (startIndex is -1), start from 0
-    const searchStartIndex = Math.max(0, startIndex);
+    // A model outside the configured list enters the fallback chain at index 0.
+    const searchStartIndex = startIndex;
 
     // Get available models
     const candidates: FallbackModel[] = [];

--- a/src/main/ConfigReloader.ts
+++ b/src/main/ConfigReloader.ts
@@ -21,7 +21,7 @@ export interface ComponentRefs {
     updateConfig: (newConfig: PluginConfig) => void;
   };
   errorPatternRegistry?: Pick<ErrorPatternRegistry,
-    'registerIgnorePatterns' | 'updateLearnedPatterns' | 'configurePatternLearning'>;
+    'registerIgnorePatterns' | 'replaceCustomPatterns' | 'updateLearnedPatterns' | 'configurePatternLearning'>;
 }
 
 /**
@@ -164,27 +164,21 @@ export class ConfigReloader {
    */
   private applyConfigChanges(newConfig: PluginConfig, configSource: string | null): void {
     const oldConfig = this.config;
-
-    // Update internal config reference
-    this.config = newConfig;
-
-    // Update components with new config
-    this.components.fallbackHandler.updateConfig(newConfig);
-
-    if (this.components.metricsManager) {
-      this.components.metricsManager.updateConfig(newConfig);
-    }
+    const changedSettings = this.getChangedSettings(oldConfig, newConfig);
 
     // Apply all runtime error-pattern settings without requiring a restart.
     if (this.components.errorPatternRegistry) {
+      const customPatterns = newConfig.errorPatterns?.custom ?? [];
+      this.components.errorPatternRegistry.replaceCustomPatterns(customPatterns);
+      this.logger.info(`Reloaded ${customPatterns.length} custom error patterns`);
+
+      const learnedPatterns = newConfig.errorPatterns?.learnedPatterns ?? [];
+      this.components.errorPatternRegistry.updateLearnedPatterns(learnedPatterns);
+      this.logger.info(`Reloaded ${learnedPatterns.length} learned patterns`);
+
       const ignorePatterns = newConfig.errorPatterns?.ignorePatterns ?? DEFAULT_ERROR_PATTERNS_CONFIG.ignorePatterns;
       this.components.errorPatternRegistry.registerIgnorePatterns(ignorePatterns);
       this.logger.info(`Reloaded ${ignorePatterns.length} ignore patterns`);
-
-      if (newConfig.errorPatterns?.learnedPatterns) {
-        this.components.errorPatternRegistry.updateLearnedPatterns(newConfig.errorPatterns.learnedPatterns);
-        this.logger.info(`Reloaded ${newConfig.errorPatterns.learnedPatterns.length} learned patterns`);
-      }
 
       const patternLearningConfig = {
         enabled: newConfig.errorPatterns?.enableLearning ?? DEFAULT_PATTERN_LEARNING_CONFIG.enabled,
@@ -199,8 +193,17 @@ export class ConfigReloader {
       );
     }
 
+    // Update the remaining components only after pattern settings have been
+    // validated and applied. Keep the internal reference unchanged on failure.
+    this.components.fallbackHandler.updateConfig(newConfig);
+
+    if (this.components.metricsManager) {
+      this.components.metricsManager.updateConfig(newConfig);
+    }
+
+    this.config = newConfig;
+
     // Log configuration changes
-    const changedSettings = this.getChangedSettings(oldConfig, newConfig);
     if (changedSettings.length > 0) {
       this.logger.info('Configuration changes applied:');
       for (const change of changedSettings) {

--- a/src/session/SubagentTracker.ts
+++ b/src/session/SubagentTracker.ts
@@ -11,11 +11,13 @@ import { SESSION_ENTRY_TTL_MS } from '../types/index.js';
 export class SubagentTracker {
   private sessionHierarchies: Map<string, SessionHierarchy>;
   private sessionToRootMap: Map<string, string>;
+  private sessionDepths: Map<string, number>;
   private maxSubagentDepth: number;
 
   constructor(config: PluginConfig) {
     this.sessionHierarchies = new Map();
     this.sessionToRootMap = new Map();
+    this.sessionDepths = new Map();
     this.maxSubagentDepth = config.maxSubagentDepth ?? 10;
   }
 
@@ -34,8 +36,13 @@ export class SubagentTracker {
     // This allows sessions to become roots when their first subagent is registered
     const hierarchy = this.getOrCreateHierarchy(rootSessionID);
 
-    const parentSubagent = hierarchy.subagents.get(parentSessionID);
-    const depth = parentSubagent ? parentSubagent.depth + 1 : 1;
+    const depth = (this.sessionDepths.get(parentSessionID) ?? 0) + 1;
+
+    // Retain minimal child classification even above the detailed tracking
+    // limit so enableSubagentFallback remains enforceable at every depth.
+    this.sessionToRootMap.set(sessionID, rootSessionID);
+    this.sessionDepths.set(sessionID, depth);
+    hierarchy.lastActivity = Date.now();
 
     // Enforce max depth
     if (depth > this.maxSubagentDepth) {
@@ -52,8 +59,6 @@ export class SubagentTracker {
     };
 
     hierarchy.subagents.set(sessionID, subagent);
-    this.sessionToRootMap.set(sessionID, rootSessionID);
-    hierarchy.lastActivity = Date.now();
 
     return true;
   }
@@ -63,6 +68,14 @@ export class SubagentTracker {
    */
   getRootSession(sessionID: string): string | null {
     return this.sessionToRootMap.get(sessionID) || null;
+  }
+
+  /**
+   * Check whether a session is a tracked child rather than a hierarchy root.
+   */
+  isSubagent(sessionID: string): boolean {
+    const rootSessionID = this.sessionToRootMap.get(sessionID);
+    return rootSessionID !== undefined && rootSessionID !== sessionID;
   }
 
   /**
@@ -118,12 +131,14 @@ export class SubagentTracker {
     const now = Date.now();
     for (const [rootSessionID, hierarchy] of this.sessionHierarchies.entries()) {
       if (now - hierarchy.lastActivity > SESSION_ENTRY_TTL_MS) {
-        // Clean up all subagents in this hierarchy
-        for (const subagentID of hierarchy.subagents.keys()) {
-          this.sessionToRootMap.delete(subagentID);
+        // Clean up detailed and minimal child mappings for this hierarchy.
+        for (const [sessionID, mappedRootSessionID] of this.sessionToRootMap.entries()) {
+          if (mappedRootSessionID === rootSessionID) {
+            this.sessionToRootMap.delete(sessionID);
+            this.sessionDepths.delete(sessionID);
+          }
         }
         this.sessionHierarchies.delete(rootSessionID);
-        this.sessionToRootMap.delete(rootSessionID);
       }
     }
   }
@@ -134,5 +149,13 @@ export class SubagentTracker {
   clearAll(): void {
     this.sessionHierarchies.clear();
     this.sessionToRootMap.clear();
+    this.sessionDepths.clear();
+  }
+
+  /**
+   * Apply hierarchy limits to subsequently created sessions.
+   */
+  updateConfig(config: PluginConfig): void {
+    this.maxSubagentDepth = config.maxSubagentDepth ?? 10;
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -366,6 +366,19 @@ export interface SessionErrorEventProperties {
 }
 
 /**
+ * Session creation event properties. OpenCode marks child sessions with parentID.
+ */
+export interface SessionCreatedEventProperties {
+  sessionID?: string;
+  info: {
+    id: string;
+    parentID?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+/**
  * Message updated event info
  */
 export interface MessageUpdatedEventInfo {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -26,6 +26,7 @@ import {
   DEFAULT_ERROR_PATTERNS_CONFIG,
   DEFAULT_PATTERN_LEARNING_CONFIG,
 } from '../config/defaults.js';
+import { isValidErrorPattern, isValidLearnedPattern } from '../config/patternValidation.js';
 
 /**
  * Default plugin configuration
@@ -35,6 +36,8 @@ export const DEFAULT_CONFIG: PluginConfig = {
   cooldownMs: DEFAULT_COOLDOWN_MS,
   enabled: true,
   fallbackMode: DEFAULT_FALLBACK_MODE,
+  maxSubagentDepth: 10,
+  enableSubagentFallback: true,
   retryPolicy: DEFAULT_RETRY_POLICY,
   circuitBreaker: DEFAULT_CIRCUIT_BREAKER_CONFIG,
   healthPersistence: DEFAULT_HEALTH_TRACKER_CONFIG,
@@ -96,6 +99,7 @@ export function validateConfig(config: Partial<PluginConfig>): PluginConfig {
   const headlessOnRateLimit = config.headlessOnRateLimit;
   const resetInterval = config.metrics?.resetInterval;
   const strategy = config.retryPolicy?.strategy;
+  const maxSubagentDepth = config.maxSubagentDepth;
   const errorPatterns = config.errorPatterns &&
     typeof config.errorPatterns === 'object' &&
     !Array.isArray(config.errorPatterns)
@@ -104,6 +108,12 @@ export function validateConfig(config: Partial<PluginConfig>): PluginConfig {
   const ignorePatterns = Array.isArray(errorPatterns?.ignorePatterns)
     ? errorPatterns.ignorePatterns.filter(isValidIgnorePattern)
     : [...(DEFAULT_ERROR_PATTERNS_CONFIG.ignorePatterns ?? [])];
+  const customPatterns = Array.isArray(errorPatterns?.custom)
+    ? errorPatterns.custom.filter(isValidErrorPattern)
+    : undefined;
+  const learnedPatterns = Array.isArray(errorPatterns?.learnedPatterns)
+    ? errorPatterns.learnedPatterns.filter(isValidLearnedPattern)
+    : undefined;
 
   return {
     ...DEFAULT_CONFIG,
@@ -111,6 +121,12 @@ export function validateConfig(config: Partial<PluginConfig>): PluginConfig {
     fallbackModels: Array.isArray(config.fallbackModels) ? config.fallbackModels : DEFAULT_CONFIG.fallbackModels,
     fallbackMode: mode && VALID_FALLBACK_MODES.includes(mode) ? mode : DEFAULT_CONFIG.fallbackMode,
     headlessOnRateLimit: headlessOnRateLimit && VALID_HEADLESS_ON_RATE_LIMIT.includes(headlessOnRateLimit) ? headlessOnRateLimit : undefined,
+    maxSubagentDepth: Number.isInteger(maxSubagentDepth) && (maxSubagentDepth ?? 0) > 0
+      ? maxSubagentDepth
+      : DEFAULT_CONFIG.maxSubagentDepth,
+    enableSubagentFallback: typeof config.enableSubagentFallback === 'boolean'
+      ? config.enableSubagentFallback
+      : DEFAULT_CONFIG.enableSubagentFallback,
     retryPolicy: config.retryPolicy ? {
       ...DEFAULT_CONFIG.retryPolicy!,
       ...config.retryPolicy,
@@ -145,7 +161,9 @@ export function validateConfig(config: Partial<PluginConfig>): PluginConfig {
     errorPatterns: errorPatterns ? {
       ...DEFAULT_ERROR_PATTERNS_CONFIG,
       ...errorPatterns,
+      custom: customPatterns,
       ignorePatterns,
+      learnedPatterns,
       enableLearning: errorPatterns.enableLearning ?? DEFAULT_PATTERN_LEARNING_CONFIG.enabled,
       autoApproveThreshold: errorPatterns.autoApproveThreshold ?? DEFAULT_PATTERN_LEARNING_CONFIG.autoApproveThreshold,
       maxLearnedPatterns: errorPatterns.maxLearnedPatterns ?? DEFAULT_PATTERN_LEARNING_CONFIG.maxLearnedPatterns,


### PR DESCRIPTION
## Summary

- consume OpenCode's real child `session.created` contract and track subagent hierarchy at every depth
- retry the rate-limited child session itself, preserve its active agent, and leave parent/sibling state untouched
- select the first fallback when a subagent's current model is outside the configured list
- apply fallback models, subagent settings, and error patterns during hot reload
- validate custom/learned patterns, make replacement atomic, and hydrate learned patterns at interactive/headless startup
- document the child-session behavior and bump the package to 1.70.8

Fixes #20

## Validation

- `npm run typecheck`
- `npm run build`
- `npm test` (645 passed, 12 skipped)
- `npm audit` (0 vulnerabilities)
- `npm pack --dry-run --json`
- real `@opencode-ai/sdk@1.18.16` client E2E: child `session.created` -> rate limit -> child messages/abort/prompt_async with agent `engram` and first fallback model; no root request
- malformed pattern strict/non-strict and reload atomicity coverage
- learned-pattern startup coverage in interactive and headless abort modes
- independent Sol review: approved with no remaining findings
