### PR TITLE
feat: complete automatic error pattern learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,36 @@ Use `errorPatterns.ignorePatterns` to add your own false-positive suppressions:
 
 The configured array replaces the built-in list. Include the built-in entries when extending it, as shown above. Set it to `[]` to disable ignore matching entirely. Entries must be non-empty strings (or `RegExp` values when configuring the plugin programmatically), and changes are applied by config hot reload.
 
+### Automatic Pattern Learning
+
+Pattern learning can recognize a new provider error format after it appears repeatedly. It observes HTTP `429` responses and errors containing explicit rate-limit signals such as quota, throttling, or structured rate-limit codes. Arbitrary server and application errors are not learned.
+
+```json
+{
+  "errorPatterns": {
+    "enableLearning": true,
+    "autoApproveThreshold": 0.8,
+    "maxLearnedPatterns": 20,
+    "minErrorFrequency": 3,
+    "learningWindowMs": 86400000
+  }
+}
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `errorPatterns.enableLearning` | boolean | `false` | Enable automatic pattern learning |
+| `errorPatterns.autoApproveThreshold` | number | `0.8` | Minimum confidence from `0` to `1` required to save a candidate |
+| `errorPatterns.maxLearnedPatterns` | integer | `20` | Maximum saved patterns; highest-confidence patterns are retained |
+| `errorPatterns.minErrorFrequency` | integer | `3` | Required observations inside the learning window |
+| `errorPatterns.learningWindowMs` | number | `86400000` | Observation window in milliseconds |
+
+The provider from OpenCode's message event is used even when the error text does not name it. After a candidate reaches the frequency and confidence thresholds, the plugin atomically updates the config file and immediately refreshes the live registry; hot reload is not required. Only extracted phrases, status codes, and structured error codes are stored, not the complete raw error body.
+
+Learned entries with confidence at or below `0.7` remain visible for review but are not used for rate-limit detection. Lowering `autoApproveThreshold` below that value can persist candidates for inspection; it does not lower the runtime detection safety floor.
+
+Learned entries are validated during startup and hot reload. Strict configuration validation rejects malformed entries; non-strict mode excludes only the invalid entries.
+
 ### Dynamic Prioritization
 
 The dynamic prioritization feature automatically reorders your fallback models based on their performance metrics, helping you use the most reliable and fastest models first.
@@ -633,6 +663,7 @@ Plugin diagnostics are sent through [OpenCode's structured application log API](
   - Model performance (requests, successes, failures, response time)
   - **Circuit breaker statistics** (state transitions, open/closed counts)
   - **Dynamic prioritization statistics** (enabled status, reorder count, models with scores)
+  - **Pattern learning statistics** (processed, learned, rejected, persistence failures, average confidence, learned-pattern matches)
 
 ### Metrics Configuration
 

--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -102,6 +102,46 @@ describe('config utilities', () => {
     expect(config.errorPatterns?.learnedPatterns).toEqual([validLearned]);
   });
 
+  it('normalizes invalid pattern learning settings to safe defaults', () => {
+    const config = validateConfig({
+      errorPatterns: {
+        enableLearning: 'yes',
+        autoApproveThreshold: 2,
+        maxLearnedPatterns: 0,
+        minErrorFrequency: -1,
+        learningWindowMs: Number.POSITIVE_INFINITY,
+      },
+    } as unknown as Partial<PluginConfig>);
+
+    expect(config.errorPatterns).toEqual(expect.objectContaining({
+      enableLearning: false,
+      autoApproveThreshold: 0.8,
+      maxLearnedPatterns: 20,
+      minErrorFrequency: 3,
+      learningWindowMs: 86400000,
+    }));
+  });
+
+  it('preserves valid pattern learning settings', () => {
+    const config = validateConfig({
+      errorPatterns: {
+        enableLearning: true,
+        autoApproveThreshold: 0.65,
+        maxLearnedPatterns: 12,
+        minErrorFrequency: 4,
+        learningWindowMs: 60000,
+      },
+    });
+
+    expect(config.errorPatterns).toEqual(expect.objectContaining({
+      enableLearning: true,
+      autoApproveThreshold: 0.65,
+      maxLearnedPatterns: 12,
+      minErrorFrequency: 4,
+      learningWindowMs: 60000,
+    }));
+  });
+
   it('normalizes invalid subagent settings to safe defaults', () => {
     const config = validateConfig({
       maxSubagentDepth: 0,

--- a/__tests__/config/watcher.test.ts
+++ b/__tests__/config/watcher.test.ts
@@ -4,7 +4,15 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ConfigWatcher } from '../../src/config/Watcher.js';
-import { writeFileSync, unlinkSync, existsSync, mkdtempSync, rmdirSync } from 'fs';
+import {
+  writeFileSync,
+  unlinkSync,
+  existsSync,
+  mkdtempSync,
+  renameSync,
+  rmdirSync,
+  symlinkSync,
+} from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -171,7 +179,55 @@ describe('ConfigWatcher', () => {
       expect(mockOnReload).toHaveBeenCalledTimes(1);
     });
 
-    it('should skip reload if already reloading', async () => {
+    it('should continue watching after the config file is atomically replaced', async () => {
+      writeFileSync(configPath, JSON.stringify({ fallbackModels: [] }));
+      const watcher = new ConfigWatcher(configPath, mockLogger, mockOnReload, {
+        enabled: true,
+        watchFile: true,
+        debounceMs: 50,
+      });
+      watcher.start();
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const replacementPath = join(testDir, '.config.json.tmp');
+      writeFileSync(replacementPath, JSON.stringify({ fallbackModels: ['first'] }));
+      renameSync(replacementPath, configPath);
+      await new Promise(resolve => setTimeout(resolve, 150));
+      const reloadsAfterReplacement = mockOnReload.mock.calls.length;
+      expect(reloadsAfterReplacement).toBeGreaterThan(0);
+
+      writeFileSync(configPath, JSON.stringify({ fallbackModels: ['second'] }));
+      await new Promise(resolve => setTimeout(resolve, 150));
+      expect(mockOnReload.mock.calls.length).toBeGreaterThan(reloadsAfterReplacement);
+      watcher.stop();
+    });
+
+    it('should watch the real target of a symlinked config file', async () => {
+      writeFileSync(configPath, JSON.stringify({ fallbackModels: [] }));
+      const linkedPath = join(testDir, 'linked-config.json');
+      symlinkSync(configPath, linkedPath);
+      const watcher = new ConfigWatcher(linkedPath, mockLogger, mockOnReload, {
+        enabled: true,
+        watchFile: true,
+        debounceMs: 50,
+      });
+
+      try {
+        watcher.start();
+        await new Promise(resolve => setTimeout(resolve, 50));
+        const replacementPath = join(testDir, '.config.json.symlink.tmp');
+        writeFileSync(replacementPath, JSON.stringify({ fallbackModels: ['updated'] }));
+        renameSync(replacementPath, configPath);
+        await new Promise(resolve => setTimeout(resolve, 150));
+
+        expect(mockOnReload).toHaveBeenCalled();
+      } finally {
+        watcher.stop();
+        unlinkSync(linkedPath);
+      }
+    });
+
+    it('should queue a follow-up reload if a change arrives while reloading', async () => {
       // Create initial config file
       writeFileSync(configPath, JSON.stringify({ fallbackModels: [] }));
 
@@ -203,9 +259,10 @@ describe('ConfigWatcher', () => {
       // Wait for both debounces
       await new Promise(resolve => setTimeout(resolve, 300));
 
-      // Should only reload once, second change should be skipped
-      expect(slowOnReload).toHaveBeenCalledTimes(1);
-      expect(mockLogger.warn).toHaveBeenCalledWith('Config changed while reload in progress, changes will be picked up after current reload completes');
+      expect(slowOnReload).toHaveBeenCalledTimes(2);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Config changed while reload in progress, queued for after current reload completes',
+      );
     });
 
     it('should handle reload errors gracefully', async () => {

--- a/__tests__/diagnosticreporter.test.ts
+++ b/__tests__/diagnosticreporter.test.ts
@@ -120,6 +120,36 @@ describe('DiagnosticReporter', () => {
       expect(report.errorPatterns.stats.byPriority).toBeDefined();
     });
 
+    it('should include live pattern learning state and outcomes', async () => {
+      const errorPatternRegistry = new ErrorPatternRegistry(logger);
+      errorPatternRegistry.configurePatternLearning({
+        enabled: true,
+        autoApproveThreshold: 0,
+        maxLearnedPatterns: 20,
+        minErrorFrequency: 1,
+        learningWindowMs: 86400000,
+      });
+      await errorPatternRegistry.learnFromError(
+        { message: 'burst_window_throttled' },
+        'provider-x',
+      );
+      reporter = new DiagnosticReporter(
+        testConfig,
+        'test-config.json',
+        undefined,
+        undefined,
+        errorPatternRegistry,
+      );
+
+      const report = reporter.generateReport();
+      expect(report.errorPatterns.learning.enabled).toBe(true);
+      expect(report.errorPatterns.learning.stats).toEqual(expect.objectContaining({
+        totalErrorsProcessed: 1,
+        patternsLearned: 1,
+      }));
+      expect(reporter.formatReport(report, 'text')).toContain('Learning Accepted: 1');
+    });
+
     it('should include circuit breaker information when provided', () => {
       const circuitBreaker = new CircuitBreaker(
         { enabled: true, failureThreshold: 5, recoveryTimeoutMs: 60000, halfOpenMaxCalls: 1, successThreshold: 2 },

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { RateLimitFallback } from '../../index';
 import { FallbackHandler } from '../src/fallback/FallbackHandler.js';
+import { PatternLearner } from '../src/errors/PatternLearner.js';
 
 // Mock the OpenCode plugin module
 vi.mock('@opencode-ai/plugin', () => ({
@@ -1909,6 +1910,64 @@ describe('Learned pattern startup hydration', () => {
     plugin.cleanup?.();
   });
 
+  it('caps configured learned patterns during startup', async () => {
+    const lowerRankedPattern = {
+      ...learnedPattern,
+      name: 'learned-lower-ranked',
+      patterns: ['vendor-lower-ranked-capacity'],
+      confidence: 0.8,
+      sampleCount: 20,
+    };
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+      fallbackModels: [{ providerID: 'google', modelID: 'gemini-fallback' }],
+      enabled: true,
+      errorPatterns: {
+        maxLearnedPatterns: 1,
+        learnedPatterns: [lowerRankedPattern, learnedPattern],
+      },
+    }));
+    const client = createMockClient();
+    vi.mocked(client.session.messages).mockResolvedValue({
+      data: [{
+        info: { id: 'message-1', role: 'user' },
+        parts: [{ type: 'text', text: 'continue the task' }],
+      }],
+    });
+    const plugin = await RateLimitFallback({
+      client: client as any,
+      directory: '/test',
+      project: {} as any,
+      worktree: '/test',
+      serverUrl: new URL('http://test.com'),
+      $: {} as any,
+    });
+
+    await plugin.event?.({
+      event: {
+        type: 'session.error',
+        properties: {
+          sessionID: 'lower-ranked-session',
+          error: { message: 'vendor-lower-ranked-capacity' },
+        },
+      },
+    });
+    expect(client.session.abort).not.toHaveBeenCalled();
+
+    await plugin.event?.({
+      event: {
+        type: 'session.error',
+        properties: {
+          sessionID: 'higher-ranked-session',
+          error: { message: 'vendor-e42-capacity-signal' },
+        },
+      },
+    });
+    expect(client.session.abort).toHaveBeenCalledWith({
+      path: { id: 'higher-ranked-session' },
+    });
+    plugin.cleanup?.();
+  });
+
   it('matches configured learned patterns immediately in headless abort mode', async () => {
     vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
       enabled: true,
@@ -1939,6 +1998,158 @@ describe('Learned pattern startup hydration', () => {
     expect(client.session.abort).toHaveBeenCalledWith({
       path: { id: 'headless-learned-session' },
     });
+  });
+
+  it('preserves built-in headless detection without a provider hint', async () => {
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+      enabled: true,
+      headlessOnRateLimit: 'abort',
+    }));
+    const client = createMockClient() as any;
+    delete client.tui;
+    const plugin = await RateLimitFallback({
+      client,
+      directory: '/test',
+      project: {} as any,
+      worktree: '/test',
+      serverUrl: new URL('http://test.com'),
+      $: {} as any,
+    });
+
+    await plugin.event?.({
+      event: {
+        type: 'session.error',
+        properties: {
+          sessionID: 'headless-overloaded-session',
+          error: { message: 'Service is overloaded' },
+        },
+      },
+    });
+
+    expect(client.session.abort).toHaveBeenCalledWith({
+      path: { id: 'headless-overloaded-session' },
+    });
+  });
+
+  it('requires a provider hint for provider-scoped learned patterns in headless mode', async () => {
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+      enabled: true,
+      headlessOnRateLimit: 'abort',
+      errorPatterns: {
+        learnedPatterns: [{ ...learnedPattern, provider: 'provider-x' }],
+      },
+    }));
+    const client = createMockClient() as any;
+    delete client.tui;
+    const plugin = await RateLimitFallback({
+      client,
+      directory: '/test',
+      project: {} as any,
+      worktree: '/test',
+      serverUrl: new URL('http://test.com'),
+      $: {} as any,
+    });
+
+    await plugin.event?.({
+      event: {
+        type: 'session.error',
+        properties: {
+          sessionID: 'headless-unknown-provider',
+          error: { message: 'vendor-e42-capacity-signal' },
+        },
+      },
+    });
+    expect(client.session.abort).not.toHaveBeenCalled();
+
+    await plugin.event?.({
+      event: {
+        type: 'message.updated',
+        properties: {
+          info: {
+            id: 'headless-provider-message',
+            sessionID: 'headless-known-provider',
+            providerID: 'provider-x',
+            error: { message: 'vendor-e42-capacity-signal' },
+          },
+        },
+      },
+    });
+    expect(client.session.abort).toHaveBeenCalledWith({
+      path: { id: 'headless-known-provider' },
+    });
+  });
+});
+
+describe('Automatic pattern learning event integration', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(existsSync).mockReturnValue(true);
+  });
+
+  it('observes an unmatched message error with its event provider', async () => {
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+      fallbackModels: [{ providerID: 'google', modelID: 'gemini-fallback' }],
+      enabled: true,
+      errorPatterns: {
+        enableLearning: true,
+        minErrorFrequency: 3,
+      },
+    }));
+    const processError = vi.spyOn(PatternLearner.prototype, 'processError')
+      .mockResolvedValue(null);
+    const client = createMockClient();
+    const plugin = await RateLimitFallback({
+      client: client as any,
+      directory: '/test',
+      project: {} as any,
+      worktree: '/test',
+      serverUrl: new URL('http://test.com'),
+      $: {} as any,
+    });
+
+    await plugin.event?.({
+      event: {
+        type: 'message.updated',
+        properties: {
+          info: {
+            id: 'message-learning-1',
+            sessionID: 'learning-session',
+            role: 'assistant',
+            providerID: 'provider-x',
+            modelID: 'model-x',
+            error: { message: 'burst_window_throttled' },
+          },
+        },
+      },
+    });
+
+    expect(processError).toHaveBeenCalledWith(
+      { message: 'burst_window_throttled' },
+      'provider-x',
+      expect.any(Array),
+    );
+    expect(client.session.abort).not.toHaveBeenCalled();
+    expect(client.session.promptAsync).not.toHaveBeenCalled();
+
+    processError.mockClear();
+    await plugin.event?.({
+      event: {
+        type: 'session.status',
+        properties: {
+          sessionID: 'learning-session',
+          status: { type: 'retry', message: 'quota_window_exhausted' },
+        },
+      },
+    });
+    expect(processError).toHaveBeenCalledWith(
+      { message: 'quota_window_exhausted' },
+      'provider-x',
+      expect.any(Array),
+    );
+    expect(client.session.abort).not.toHaveBeenCalled();
+
+    plugin.cleanup?.();
+    processError.mockRestore();
   });
 });
 

--- a/__tests__/metrics/metricsmanager.test.ts
+++ b/__tests__/metrics/metricsmanager.test.ts
@@ -34,6 +34,14 @@ describe('MetricsManager', () => {
       expect(metrics.fallbacks.total).toBe(0);
       expect(metrics.retries.total).toBe(0);
       expect(metrics.modelPerformance).toBeInstanceOf(Map);
+      expect(metrics.patternLearning).toEqual({
+        totalErrorsProcessed: 0,
+        patternsLearned: 0,
+        patternsRejected: 0,
+        persistenceFailures: 0,
+        averageConfidence: 0,
+        learnedPatternMatches: 0,
+      });
       expect(metrics.startedAt).toBeGreaterThan(0);
     });
 
@@ -48,6 +56,39 @@ describe('MetricsManager', () => {
       );
 
       expect(manager.getMetrics()).toBeDefined();
+    });
+  });
+
+  describe('Pattern Learning Metrics', () => {
+    it('should track learning outcomes, confidence, and learned-pattern usage', () => {
+      metricsManager.recordPatternErrorProcessed();
+      metricsManager.recordPatternErrorProcessed();
+      metricsManager.recordPatternLearned(0.8);
+      metricsManager.recordPatternLearned(0.9);
+      metricsManager.recordPatternRejected();
+      metricsManager.recordPatternPersistenceFailure();
+      metricsManager.recordLearnedPatternMatch();
+      metricsManager.recordLearnedPatternMatch();
+
+      expect(metricsManager.getMetrics().patternLearning).toEqual({
+        totalErrorsProcessed: 2,
+        patternsLearned: 2,
+        patternsRejected: 1,
+        persistenceFailures: 1,
+        averageConfidence: 0.85,
+        learnedPatternMatches: 2,
+      });
+    });
+
+    it('should include pattern learning in every export format', () => {
+      metricsManager.recordPatternLearned(0.75);
+      metricsManager.recordLearnedPatternMatch();
+
+      expect(JSON.parse(metricsManager.export('json')).patternLearning).toEqual(
+        expect.objectContaining({ averageConfidence: 0.75, learnedPatternMatches: 1 }),
+      );
+      expect(metricsManager.export('pretty')).toContain('Learned Pattern Matches: 1');
+      expect(metricsManager.export('csv')).toContain('average_confidence,learned_pattern_matches');
     });
   });
 
@@ -408,6 +449,8 @@ describe('MetricsManager', () => {
       metricsManager.recordRateLimit('anthropic', 'claude-3-5-sonnet-20250514');
       metricsManager.recordFallbackStart();
       metricsManager.recordFallbackFailure();
+      metricsManager.recordPatternLearned(0.9);
+      metricsManager.recordLearnedPatternMatch();
 
       metricsManager.reset();
 
@@ -416,6 +459,8 @@ describe('MetricsManager', () => {
       expect(metrics.fallbacks.total).toBe(0);
       expect(metrics.retries.total).toBe(0);
       expect(metrics.rateLimits.size).toBe(0);
+      expect(metrics.patternLearning.patternsLearned).toBe(0);
+      expect(metrics.patternLearning.learnedPatternMatches).toBe(0);
       expect(mockLogger.debug).toHaveBeenCalledWith('Metrics reset');
     });
   });
@@ -502,12 +547,18 @@ describe('MetricsManager', () => {
       manager.recordRateLimit('anthropic', 'claude-3-5-sonnet-20250514');
       manager.recordFallbackFailure();
       manager.recordRetryFailure();
+      manager.recordPatternErrorProcessed();
+      manager.recordPatternLearned(0.9);
+      manager.recordLearnedPatternMatch();
 
       const metrics = manager.getMetrics();
 
       expect(metrics.fallbacks.total).toBe(0);
       expect(metrics.retries.total).toBe(0);
       expect(metrics.rateLimits.size).toBe(0);
+      expect(metrics.patternLearning.totalErrorsProcessed).toBe(0);
+      expect(metrics.patternLearning.patternsLearned).toBe(0);
+      expect(metrics.patternLearning.learnedPatternMatches).toBe(0);
     });
 
     it('should handle multiple models with same provider', () => {

--- a/__tests__/pattern-extractor.test.ts
+++ b/__tests__/pattern-extractor.test.ts
@@ -60,6 +60,15 @@ describe('PatternExtractor', () => {
       expect(pattern?.provider).toBe('openai');
     });
 
+    it('should prefer an event provider hint for unknown providers', () => {
+      const pattern = extractor.extractPattern(
+        { message: 'burst_window_throttled' },
+        'Provider-X',
+      );
+
+      expect(pattern?.provider).toBe('provider-x');
+    });
+
     it('should extract HTTP status codes', () => {
       const error = {
         message: 'Rate limit error',
@@ -92,6 +101,18 @@ describe('PatternExtractor', () => {
       const pattern = extractor.extractPattern(error);
 
       expect(pattern?.errorCodes).toContain('insufficient_quota');
+    });
+
+    it('should preserve the complete structured rate-limit code', () => {
+      const pattern = extractor.extractPattern({
+        message: 'ProviderX: rate_limit_exceeded_error',
+      }, 'providerx');
+
+      expect(pattern?.errorCodes).toContain('rate_limit_exceeded_error');
+    });
+
+    it('should not treat a generic exceeded message as a learning signal', () => {
+      expect(extractor.extractPattern({ message: 'Memory allocation exceeded' }, 'providerx')).toBeNull();
     });
 
     it('should extract from responseBody', () => {
@@ -215,6 +236,46 @@ describe('PatternExtractor', () => {
       expect(pattern?.errorCodes).toContain('resource_exhausted');
     });
 
+    it('should not treat a bare quota word as a learnable rate-limit signal', () => {
+      const pattern = extractor.extractPattern({
+        message: 'Quota information is temporarily unavailable',
+      }, 'provider-x');
+
+      expect(pattern).toBeNull();
+    });
+
+    it.each([
+      'quota_information unavailable',
+      'quota_usage_metadata invalid',
+      'not_quota_related',
+    ])('should not treat a non-depletion quota code as learnable: %s', message => {
+      expect(extractor.extractPattern({ message }, 'provider-x')).toBeNull();
+    });
+
+    it('should retain quota codes with explicit depletion semantics', () => {
+      const pattern = extractor.extractPattern({
+        message: 'quota_window_exhausted',
+      }, 'provider-x');
+
+      expect(pattern?.errorCodes).toContain('quota_window_exhausted');
+    });
+
+    it.each([
+      'Invalid request limit configuration',
+      'Daily limit settings are malformed',
+      'Quota limit configuration is invalid',
+    ])('should not learn non-exhaustion limit configuration text: %s', message => {
+      expect(extractor.extractPattern({ message }, 'provider-x')).toBeNull();
+    });
+
+    it('should extract an explicitly exhausted request limit', () => {
+      const pattern = extractor.extractPattern({
+        message: 'Request limit reached for this account',
+      }, 'provider-x');
+
+      expect(pattern?.phrases).toContain('request limit reached');
+    });
+
     it('should handle empty error object gracefully', () => {
       const error = {};
 
@@ -250,6 +311,14 @@ describe('PatternExtractor', () => {
         const pattern = extractor.extractPattern({ message });
         expect(pattern?.provider).toBe(expected);
       }
+    });
+
+    it('should not infer cohere from a larger unrelated word', () => {
+      const pattern = extractor.extractPattern({
+        message: 'incoherent resource_exhausted response',
+      });
+
+      expect(pattern?.provider).toBeNull();
     });
   });
 });

--- a/__tests__/pattern-learner.test.ts
+++ b/__tests__/pattern-learner.test.ts
@@ -1,14 +1,27 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { afterEach, describe, it, expect, beforeEach, vi } from 'vitest';
 import { PatternLearner } from '../src/errors/PatternLearner';
 import type { PatternLearningConfig } from '../src/types/index';
 import type { Logger } from '../logger';
+import {
+  lstatSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 describe('PatternLearner', () => {
   let learner: PatternLearner;
   let config: PatternLearningConfig;
   let mockLogger: Logger;
+  let tempDirs: string[];
 
   beforeEach(() => {
+    tempDirs = [];
     config = {
       enabled: true,
       autoApproveThreshold: 0.8,
@@ -25,6 +38,14 @@ describe('PatternLearner', () => {
     } as unknown as Logger;
 
     learner = new PatternLearner(config, mockLogger);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    for (const directory of tempDirs) {
+      rmSync(directory, { recursive: true, force: true });
+    }
   });
 
   describe('updateConfig()', () => {
@@ -77,6 +98,16 @@ describe('PatternLearner', () => {
       };
 
       const result = await learner.processError(error);
+
+      expect(result).toBeNull();
+    });
+
+    it('should not infer a provider from a substring inside another word', async () => {
+      learner.updateConfig({ ...config, minErrorFrequency: 1, autoApproveThreshold: 0 });
+
+      const result = await learner.processError({
+        message: 'incoherent resource_exhausted response',
+      });
 
       expect(result).toBeNull();
     });
@@ -192,6 +223,254 @@ describe('PatternLearner', () => {
       expect(result).not.toBeNull();
       expect(result?.patterns).toContain('429');
     });
+
+    it('should learn an unknown provider from the event provider hint', async () => {
+      learner.updateConfig({ ...config, minErrorFrequency: 1, autoApproveThreshold: 0 });
+
+      const result = await learner.processError(
+        { message: 'burst_window_throttled' },
+        'Provider-X',
+      );
+
+      expect(result?.provider).toBe('provider-x');
+      expect(result?.patterns).toContain('burst_window_throttled');
+    });
+
+    it('should not learn a server error status without a rate-limit signal', async () => {
+      learner.updateConfig({ ...config, minErrorFrequency: 1, autoApproveThreshold: 0 });
+
+      const result = await learner.processError({ data: { statusCode: 503 } }, 'provider-x');
+
+      expect(result).toBeNull();
+      expect(learner.getStats().patternsLearned).toBe(0);
+    });
+
+    it.each([
+      'Invalid request limit configuration',
+      'Daily limit settings are malformed',
+      'Quota limit configuration is invalid',
+      'quota_information unavailable',
+      'quota_usage_metadata invalid',
+      'not_quota_related',
+    ])('should not learn application configuration text: %s', async message => {
+      learner.updateConfig({ ...config, minErrorFrequency: 1, autoApproveThreshold: 0 });
+
+      expect(await learner.processError({ message }, 'provider-x')).toBeNull();
+      expect(await learner.processError({ message }, 'provider-x')).toBeNull();
+      expect(await learner.processError({ message }, 'provider-x')).toBeNull();
+      expect(learner.getStats().patternsLearned).toBe(0);
+    });
+
+    it('should reset candidate frequency after the learning window expires', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-08-12T00:00:00.000Z'));
+      learner.updateConfig({
+        ...config,
+        minErrorFrequency: 3,
+        autoApproveThreshold: 0,
+        learningWindowMs: 1000,
+      });
+      const error = { message: 'burst_window_throttled' };
+
+      await learner.processError(error, 'provider-x');
+      await learner.processError(error, 'provider-x');
+      vi.advanceTimersByTime(1001);
+
+      expect(await learner.processError(error, 'provider-x')).toBeNull();
+      expect(await learner.processError(error, 'provider-x')).toBeNull();
+      expect(await learner.processError(error, 'provider-x')).not.toBeNull();
+    });
+
+    it('should bound high-cardinality candidate tracking with LRU eviction', async () => {
+      learner.updateConfig({
+        ...config,
+        maxLearnedPatterns: 2,
+        minErrorFrequency: 3,
+      });
+
+      for (let index = 0; index < 500; index++) {
+        await learner.processError(
+          { message: `req_${index}_rate_limit` },
+          'provider-x',
+        );
+      }
+
+      expect((learner as any).patternTracking.size).toBeLessThanOrEqual(100);
+    });
+
+    it('should keep the hard tracking cap while unique candidates await persistence', async () => {
+      learner.updateConfig({
+        ...config,
+        maxLearnedPatterns: 2,
+        minErrorFrequency: 1,
+        autoApproveThreshold: 0,
+      });
+
+      let releasePersistence!: () => void;
+      const persistenceGate = new Promise<void>(resolve => {
+        releasePersistence = resolve;
+      });
+      const appendSpy = vi.spyOn((learner as any).storage, 'appendLearnedPatterns')
+        .mockImplementation(async (patterns: any[]) => {
+          await persistenceGate;
+          return patterns;
+        });
+
+      const processing = Array.from({ length: 500 }, (_, index) => learner.processError(
+        { message: `req_${index}_rate_limit` },
+        'provider-x',
+      ));
+
+      await vi.waitFor(() => expect(appendSpy).toHaveBeenCalledTimes(1));
+      expect((learner as any).patternTracking.size).toBe(100);
+      expect((learner as any).pendingPatternKeys.size).toBe(100);
+
+      releasePersistence();
+      await Promise.all(processing);
+
+      expect(appendSpy).toHaveBeenCalledTimes(100);
+      expect(learner.getStats()).toEqual(expect.objectContaining({
+        patternsLearned: 100,
+        patternsRejected: 400,
+      }));
+      expect((learner as any).patternTracking.size).toBe(0);
+      expect((learner as any).pendingPatternKeys.size).toBe(0);
+    });
+
+    it('should record and surface configured persistence failures', async () => {
+      learner.updateConfig({ ...config, minErrorFrequency: 1, autoApproveThreshold: 0 });
+      learner.setConfigFilePath(join(tmpdir(), `missing-pattern-dir-${Date.now()}`, 'config.json'));
+
+      await expect(learner.processError(
+        { message: 'burst_window_throttled' },
+        'provider-x',
+      )).rejects.toThrow('Failed to write learned patterns');
+
+      expect(learner.getStats()).toEqual(expect.objectContaining({
+        patternsLearned: 0,
+        persistenceFailures: 1,
+      }));
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Failed to persist learned pattern',
+        expect.any(Object),
+      );
+    });
+
+    it('should serialize concurrent saves without losing learned patterns', async () => {
+      const directory = mkdtempSync(join(tmpdir(), 'pattern-learner-concurrency-'));
+      tempDirs.push(directory);
+      const configPath = join(directory, 'rate-limit-fallback.json');
+      writeFileSync(configPath, JSON.stringify({ errorPatterns: { enableLearning: true } }));
+      learner.updateConfig({ ...config, minErrorFrequency: 1, autoApproveThreshold: 0 });
+      learner.setConfigFilePath(configPath);
+
+      await Promise.all([
+        learner.processError({ message: 'burst_window_throttled' }, 'provider-a'),
+        learner.processError({ message: 'quota_window_exhausted' }, 'provider-b'),
+      ]);
+
+      const saved = JSON.parse(readFileSync(configPath, 'utf-8'));
+      expect(saved.errorPatterns.learnedPatterns).toHaveLength(2);
+      expect(saved.errorPatterns.learnedPatterns.map((pattern: any) => pattern.provider).sort())
+        .toEqual(['provider-a', 'provider-b']);
+      expect(readdirSync(directory).some(name => name.endsWith('.pattern-learning.lock'))).toBe(false);
+    });
+
+    it('should serialize saves across independent learner instances', async () => {
+      const directory = mkdtempSync(join(tmpdir(), 'pattern-learner-cross-instance-'));
+      tempDirs.push(directory);
+      const configPath = join(directory, 'rate-limit-fallback.json');
+      writeFileSync(configPath, JSON.stringify({ errorPatterns: { enableLearning: true } }));
+      const learningConfig = { ...config, minErrorFrequency: 1, autoApproveThreshold: 0 };
+      const learnerA = new PatternLearner(learningConfig, mockLogger);
+      const learnerB = new PatternLearner(learningConfig, mockLogger);
+      learnerA.setConfigFilePath(configPath);
+      learnerB.setConfigFilePath(configPath);
+
+      await Promise.all([
+        learnerA.processError({ message: 'burst_window_throttled' }, 'provider-a'),
+        learnerB.processError({ message: 'quota_window_exhausted' }, 'provider-b'),
+      ]);
+
+      const saved = JSON.parse(readFileSync(configPath, 'utf-8'));
+      expect(saved.errorPatterns.learnedPatterns).toHaveLength(2);
+      expect(saved.errorPatterns.learnedPatterns.map((pattern: any) => pattern.provider).sort())
+        .toEqual(['provider-a', 'provider-b']);
+    });
+
+    it('should preserve a symlinked config path and update its real target', async () => {
+      const directory = mkdtempSync(join(tmpdir(), 'pattern-learner-symlink-'));
+      tempDirs.push(directory);
+      const targetPath = join(directory, 'actual-config.json');
+      const symlinkPath = join(directory, 'rate-limit-fallback.json');
+      writeFileSync(targetPath, JSON.stringify({ errorPatterns: { enableLearning: true } }));
+      symlinkSync(targetPath, symlinkPath);
+      learner.updateConfig({ ...config, minErrorFrequency: 1, autoApproveThreshold: 0 });
+      learner.setConfigFilePath(symlinkPath);
+
+      await learner.processError({ message: 'burst_window_throttled' }, 'provider-x');
+
+      expect(lstatSync(symlinkPath).isSymbolicLink()).toBe(true);
+      const saved = JSON.parse(readFileSync(targetPath, 'utf-8'));
+      expect(saved.errorPatterns.learnedPatterns).toHaveLength(1);
+      expect(saved.errorPatterns.learnedPatterns[0].provider).toBe('provider-x');
+    });
+
+    it('should ignore other-provider patterns when scoring confidence', async () => {
+      learner.updateConfig({ ...config, minErrorFrequency: 1, autoApproveThreshold: 0.8 });
+      const existingOtherProvider = {
+        name: 'learned-provider-b-throttle',
+        provider: 'provider-b',
+        patterns: ['burst_window_throttled', 'throttled'],
+        priority: 70,
+      };
+
+      const learned = await learner.processError(
+        { message: 'burst_window_throttled' },
+        'provider-a',
+        [existingOtherProvider],
+      );
+
+      expect(learned).not.toBeNull();
+      expect(learned?.provider).toBe('provider-a');
+      expect(learned?.confidence).toBe(1);
+    });
+
+    it('should report learning activity to the metrics sink', async () => {
+      const metricsSink = {
+        recordPatternErrorProcessed: vi.fn(),
+        recordPatternLearned: vi.fn(),
+        recordPatternRejected: vi.fn(),
+        recordPatternPersistenceFailure: vi.fn(),
+        recordLearnedPatternMatch: vi.fn(),
+      };
+      learner = new PatternLearner(
+        { ...config, minErrorFrequency: 1, autoApproveThreshold: 0 },
+        mockLogger,
+        undefined,
+        metricsSink,
+      );
+
+      await learner.processError({ message: 'burst_window_throttled' }, 'provider-x');
+
+      expect(metricsSink.recordPatternErrorProcessed).toHaveBeenCalledOnce();
+      expect(metricsSink.recordPatternLearned).toHaveBeenCalledWith(1);
+      expect(metricsSink.recordPatternRejected).not.toHaveBeenCalled();
+      expect(metricsSink.recordPatternPersistenceFailure).not.toHaveBeenCalled();
+    });
+
+    it('should not persist non-429 server statuses as standalone match patterns', async () => {
+      learner.updateConfig({ ...config, minErrorFrequency: 1, autoApproveThreshold: 0 });
+
+      const learned = await learner.processError({
+        message: 'burst_window_throttled',
+        data: { statusCode: 503 },
+      }, 'provider-x');
+
+      expect(learned).not.toBeNull();
+      expect(learned?.patterns).toContain('burst_window_throttled');
+      expect(learned?.patterns).not.toContain('503');
+    });
   });
 
   describe('loadLearnedPatterns()', () => {
@@ -212,8 +491,6 @@ describe('PatternLearner', () => {
 
   describe('saveLearnedPatterns()', () => {
     it('should save patterns', async () => {
-      learner.setConfigFilePath('/path/to/config.json');
-
       const patterns = [
         {
           name: 'p1',
@@ -225,12 +502,10 @@ describe('PatternLearner', () => {
         },
       ];
 
-      await expect(learner.saveLearnedPatterns(patterns)).resolves.not.toThrow();
+      await expect(learner.saveLearnedPatterns(patterns)).resolves.toHaveLength(1);
     });
 
     it('should merge and clean patterns before saving', async () => {
-      learner.setConfigFilePath('/path/to/config.json');
-
       const patterns = [
         {
           name: 'p1',

--- a/__tests__/pattern-storage.test.ts
+++ b/__tests__/pattern-storage.test.ts
@@ -10,6 +10,17 @@ describe('PatternStorage', () => {
   let config: PatternLearningConfig;
 
   beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fs.realpath).mockImplementation(async path => String(path));
+    vi.mocked(fs.open).mockResolvedValue({
+      close: vi.fn().mockResolvedValue(undefined),
+      writeFile: vi.fn().mockResolvedValue(undefined),
+    } as any);
+    vi.mocked(fs.readFile).mockImplementation(async path =>
+      String(path).endsWith('.pattern-learning.lock')
+        ? ''
+        : JSON.stringify({ enabled: true })
+    );
     config = {
       enabled: true,
       autoApproveThreshold: 0.8,
@@ -99,6 +110,21 @@ describe('PatternStorage', () => {
 
       // Should not merge
       expect(result.length).toBe(2);
+    });
+
+    it('should not merge similar patterns from different providers', () => {
+      const patterns: LearnedPattern[] = [
+        {
+          name: 'p1', provider: 'provider-a', patterns: ['burst throttled'], priority: 70,
+          confidence: 0.9, learnedAt: '2026-01-01', sampleCount: 5,
+        },
+        {
+          name: 'p2', provider: 'provider-b', patterns: ['burst throttled'], priority: 70,
+          confidence: 0.8, learnedAt: '2026-01-01', sampleCount: 3,
+        },
+      ];
+
+      expect(storage.mergeSimilarPatterns(patterns)).toHaveLength(2);
     });
 
     it('should use maximum confidence when merging', () => {
@@ -269,7 +295,7 @@ describe('PatternStorage', () => {
         },
       ];
 
-      await expect(storage.saveLearnedPatterns(patterns)).resolves.not.toThrow();
+      await expect(storage.saveLearnedPatterns(patterns)).resolves.toBe(false);
     });
 
     it('should handle file write errors gracefully', async () => {
@@ -288,7 +314,27 @@ describe('PatternStorage', () => {
         },
       ];
 
-      await expect(storage.saveLearnedPatterns(patterns)).resolves.not.toThrow();
+      await expect(storage.saveLearnedPatterns(patterns)).resolves.toBe(false);
+    });
+
+    it('should atomically replace the config file after writing a sibling temporary file', async () => {
+      const configPath = '/path/to/rate-limit-fallback.json';
+      storage.setConfigFilePath(configPath);
+      vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify({ enabled: true }) as any);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+      vi.mocked(fs.rename).mockResolvedValue(undefined);
+      const patterns: LearnedPattern[] = [{
+        name: 'p1', patterns: ['burst throttled'], priority: 70,
+        confidence: 0.9, learnedAt: '2026-01-01', sampleCount: 3,
+      }];
+
+      const saved = await storage.saveLearnedPatterns(patterns);
+
+      expect(saved).toBe(true);
+      const tempPath = vi.mocked(fs.writeFile).mock.calls[0][0] as string;
+      expect(tempPath).toContain('.rate-limit-fallback.json.');
+      expect(vi.mocked(fs.writeFile).mock.calls[0][2]).toEqual({ encoding: 'utf-8', mode: 0o600 });
+      expect(fs.rename).toHaveBeenCalledWith(tempPath, configPath);
     });
   });
 

--- a/__tests__/patternregistry.test.ts
+++ b/__tests__/patternregistry.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ErrorPatternRegistry } from '../src/errors/PatternRegistry';
 import { Logger } from '../logger';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 describe('ErrorPatternRegistry', () => {
   let registry: ErrorPatternRegistry;
@@ -163,10 +166,7 @@ describe('ErrorPatternRegistry', () => {
       expect(result).toBe(true);
     });
 
-    it.skip('should NOT detect 429 as part of a larger number (e.g., 4291)', () => {
-      // Note: The current regex pattern \b429\b will match 429 in 4291
-      // because JavaScript's word boundary treats digit boundaries as word boundaries
-      // This test is skipped until a stricter pattern is implemented
+    it('should NOT detect 429 as part of a larger number (e.g., 4291)', () => {
       const error = {
         message: 'Request ID: 4291',
       };
@@ -215,8 +215,14 @@ describe('ErrorPatternRegistry', () => {
       ];
 
       for (const error of errors) {
-        expect(registry.isRateLimitError(error)).toBe(true);
+        expect(registry.isRateLimitError(error, 'anthropic')).toBe(true);
       }
+    });
+
+    it('should preserve built-in provider detection when no provider hint is available', () => {
+      expect(registry.isRateLimitError({ message: 'Service is overloaded' })).toBe(true);
+      expect(registry.isRateLimitError({ message: 'resource exhausted' })).toBe(true);
+      expect(registry.isRateLimitError({ message: 'insufficient_quota' })).toBe(true);
     });
 
     it('should detect Google/Gemini-specific rate limit messages', () => {
@@ -229,7 +235,7 @@ describe('ErrorPatternRegistry', () => {
       ];
 
       for (const error of errors) {
-        expect(registry.isRateLimitError(error)).toBe(true);
+        expect(registry.isRateLimitError(error, 'google')).toBe(true);
       }
     });
 
@@ -243,7 +249,7 @@ describe('ErrorPatternRegistry', () => {
       ];
 
       for (const error of errors) {
-        expect(registry.isRateLimitError(error)).toBe(true);
+        expect(registry.isRateLimitError(error, 'openai')).toBe(true);
       }
     });
 
@@ -431,6 +437,19 @@ describe('ErrorPatternRegistry', () => {
       expect(() => registry.replaceCustomPatterns([null, {}] as any)).not.toThrow();
       expect(registry.isRateLimitError({ message: 'unrelated provider failure' })).toBe(false);
     });
+
+    it('normalizes provider whitespace when matching custom patterns', () => {
+      registry.replaceCustomPatterns([{
+        name: 'provider-capacity',
+        provider: ' Provider-X ',
+        patterns: ['provider-capacity-e42'],
+        priority: 95,
+      }]);
+
+      expect(registry.isRateLimitError({ message: 'provider-capacity-e42' }, 'provider-x')).toBe(true);
+      expect(registry.isRateLimitError({ message: 'provider-capacity-e42' }, 'provider-y')).toBe(false);
+      expect(registry.isRateLimitError({ message: 'provider-capacity-e42' })).toBe(false);
+    });
   });
 
   describe('updateLearnedPatterns()', () => {
@@ -448,6 +467,22 @@ describe('ErrorPatternRegistry', () => {
 
       expect(registry.getLearnedPatterns()).toEqual([valid]);
       expect(registry.isRateLimitError({ message: 'learned capacity signal' })).toBe(true);
+    });
+
+    it('should retain low-confidence entries for review without using them for detection', () => {
+      const lowConfidence = {
+        name: 'learned-low-confidence',
+        patterns: ['uncertain-capacity-signal'],
+        priority: 70,
+        confidence: 0.7,
+        learnedAt: '2026-08-12T00:00:00.000Z',
+        sampleCount: 3,
+      };
+
+      registry.updateLearnedPatterns([lowConfidence]);
+
+      expect(registry.getLearnedPatterns()).toEqual([lowConfidence]);
+      expect(registry.isRateLimitError({ message: 'uncertain-capacity-signal' })).toBe(false);
     });
   });
 
@@ -602,6 +637,140 @@ describe('ErrorPatternRegistry', () => {
       registry.configurePatternLearning({ ...learningConfig, enabled: true });
       expect(registry.getPatternLearner()).toBe(learner);
       expect(registry.isLearningEnabled()).toBe(true);
+    });
+
+    it('should enforce a lowered learned-pattern limit immediately', () => {
+      registry.configurePatternLearning({ ...learningConfig, maxLearnedPatterns: 3 });
+      registry.updateLearnedPatterns([
+        {
+          name: 'learned-low',
+          patterns: ['vendor-low-capacity'],
+          priority: 70,
+          confidence: 0.8,
+          learnedAt: '2026-08-12T00:00:00.000Z',
+          sampleCount: 20,
+        },
+        {
+          name: 'learned-high-fewer-samples',
+          patterns: ['vendor-high-fewer'],
+          priority: 70,
+          confidence: 0.95,
+          learnedAt: '2026-08-12T00:00:00.000Z',
+          sampleCount: 2,
+        },
+        {
+          name: 'learned-high-more-samples',
+          patterns: ['vendor-high-more'],
+          priority: 70,
+          confidence: 0.95,
+          learnedAt: '2026-08-12T00:00:00.000Z',
+          sampleCount: 5,
+        },
+      ]);
+
+      registry.configurePatternLearning({ ...learningConfig, maxLearnedPatterns: 1 });
+
+      expect(registry.getLearnedPatterns().map(pattern => pattern.name))
+        .toEqual(['learned-high-more-samples']);
+      expect(registry.isRateLimitError({ message: 'vendor-high-more' })).toBe(true);
+      expect(registry.isRateLimitError({ message: 'vendor-high-fewer' })).toBe(false);
+    });
+
+    it('should persist, activate, and provider-scope a learned pattern immediately', async () => {
+      const directory = mkdtempSync(join(tmpdir(), 'pattern-registry-learning-'));
+      const configPath = join(directory, 'rate-limit-fallback.json');
+      writeFileSync(configPath, JSON.stringify({ errorPatterns: { enableLearning: true } }));
+
+      try {
+        registry.configurePatternLearning({
+          ...learningConfig,
+          enabled: true,
+          autoApproveThreshold: 0,
+          minErrorFrequency: 2,
+        }, configPath);
+        const error = { message: 'burst_window_throttled' };
+
+        expect(registry.isRateLimitError(error, 'provider-x')).toBe(false);
+        expect(await registry.learnFromError(error, 'provider-x')).toBeNull();
+        expect(await registry.learnFromError(error, 'provider-x')).not.toBeNull();
+
+        expect(registry.isRateLimitError(error, 'provider-x')).toBe(true);
+        expect(registry.isRateLimitError(error, 'provider-y')).toBe(false);
+        expect(registry.isRateLimitError(error)).toBe(false);
+        expect(registry.isRateLimitError(
+          { message: `provider-x: ${error.message}` },
+        )).toBe(true);
+        const saved = JSON.parse(readFileSync(configPath, 'utf-8'));
+        expect(saved.errorPatterns.learnedPatterns).toHaveLength(1);
+        expect(saved.errorPatterns.learnedPatterns[0].provider).toBe('provider-x');
+      } finally {
+        rmSync(directory, { recursive: true, force: true });
+      }
+    });
+
+    it('should count live matches of learned patterns', () => {
+      const metricsSink = {
+        recordPatternErrorProcessed: vi.fn(),
+        recordPatternLearned: vi.fn(),
+        recordPatternRejected: vi.fn(),
+        recordPatternPersistenceFailure: vi.fn(),
+        recordLearnedPatternMatch: vi.fn(),
+      };
+      registry.setPatternLearningMetricsSink(metricsSink);
+      registry.updateLearnedPatterns([{
+        name: 'learned-provider-capacity',
+        provider: 'provider-x',
+        patterns: ['vendor-capacity-e42'],
+        priority: 70,
+        confidence: 0.9,
+        learnedAt: '2026-08-12T00:00:00.000Z',
+        sampleCount: 3,
+      }]);
+
+      expect(registry.isRateLimitError({ message: 'vendor-capacity-e42' }, 'provider-x')).toBe(true);
+      expect(metricsSink.recordLearnedPatternMatch).toHaveBeenCalledOnce();
+    });
+
+    it('should promote an inactive same-provider pattern after new observations', async () => {
+      const directory = mkdtempSync(join(tmpdir(), 'pattern-registry-promotion-'));
+      const configPath = join(directory, 'rate-limit-fallback.json');
+      const inactivePattern = {
+        name: 'learned-provider-x-throttle',
+        provider: 'provider-x',
+        patterns: ['burst_window_throttled', 'throttled'],
+        priority: 70,
+        confidence: 0.7,
+        learnedAt: '2026-08-12T00:00:00.000Z',
+        sampleCount: 1,
+      };
+      writeFileSync(configPath, JSON.stringify({
+        errorPatterns: {
+          enableLearning: true,
+          learnedPatterns: [inactivePattern],
+        },
+      }));
+
+      try {
+        registry.updateLearnedPatterns([inactivePattern]);
+        registry.configurePatternLearning({
+          ...learningConfig,
+          enabled: true,
+          autoApproveThreshold: 0.8,
+          minErrorFrequency: 1,
+        }, configPath);
+        const error = { message: 'burst_window_throttled' };
+        expect(registry.isRateLimitError(error, 'provider-x')).toBe(false);
+
+        expect(await registry.learnFromError(error, 'provider-x')).not.toBeNull();
+
+        const promoted = registry.getLearnedPatterns();
+        expect(promoted).toHaveLength(1);
+        expect(promoted[0].confidence).toBeGreaterThan(0.7);
+        expect(promoted[0].sampleCount).toBe(2);
+        expect(registry.isRateLimitError(error, 'provider-x')).toBe(true);
+      } finally {
+        rmSync(directory, { recursive: true, force: true });
+      }
     });
   });
 

--- a/__tests__/validator.test.ts
+++ b/__tests__/validator.test.ts
@@ -504,6 +504,33 @@ describe('ConfigValidator', () => {
         'errorPatterns.learnedPatterns[0].sampleCount',
       ]));
     });
+
+    it('should reject invalid pattern learning settings (strict mode)', () => {
+      const config = {
+        fallbackModels: [{ providerID: 'anthropic', modelID: 'claude-3-5-sonnet-20250514' }],
+        cooldownMs: 5000,
+        enabled: true,
+        fallbackMode: 'cycle' as const,
+        errorPatterns: {
+          enableLearning: 'yes',
+          autoApproveThreshold: 1.1,
+          maxLearnedPatterns: 0,
+          minErrorFrequency: 1.5,
+          learningWindowMs: 0,
+        },
+      };
+
+      const result = validator.validate(config as any, { strict: true });
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors.map(e => e.path)).toEqual(expect.arrayContaining([
+        'errorPatterns.enableLearning',
+        'errorPatterns.autoApproveThreshold',
+        'errorPatterns.maxLearnedPatterns',
+        'errorPatterns.minErrorFrequency',
+        'errorPatterns.learningWindowMs',
+      ]));
+    });
   });
 
   describe('getDiagnostics() - Diagnostic Output', () => {

--- a/index.ts
+++ b/index.ts
@@ -5,11 +5,12 @@
  */
 
 import type { Plugin } from "@opencode-ai/plugin";
-import { createLogger, type LogSink } from "./logger.js";
+import { createLogger, type Logger, type LogSink } from "./logger.js";
 
 // Import modular components
 import type {
   MessageUpdatedEventProperties,
+  PluginConfig,
   SessionCreatedEventProperties,
   SessionErrorEventProperties,
   SessionStatusEventProperties,
@@ -56,6 +57,44 @@ function getObjectDiff<T extends Record<string, unknown>>(obj1: T, obj2: T): str
   }
 
   return diffs;
+}
+
+function initializeErrorPatternRegistry(
+  config: PluginConfig,
+  configSource: string | null,
+  logger: Logger,
+): ErrorPatternRegistry {
+  const registry = new ErrorPatternRegistry(logger, config.errorPatterns?.ignorePatterns);
+  registry.replaceCustomPatterns(config.errorPatterns?.custom ?? []);
+
+  const patternLearningConfig = {
+    enabled: Boolean(config.errorPatterns?.enableLearning && configSource),
+    autoApproveThreshold: config.errorPatterns?.autoApproveThreshold ?? 0.8,
+    maxLearnedPatterns: config.errorPatterns?.maxLearnedPatterns ?? 20,
+    minErrorFrequency: config.errorPatterns?.minErrorFrequency ?? 3,
+    learningWindowMs: config.errorPatterns?.learningWindowMs ?? 86400000,
+  };
+  registry.configurePatternLearning(patternLearningConfig, configSource ?? undefined);
+  registry.updateLearnedPatterns(config.errorPatterns?.learnedPatterns ?? []);
+
+  if (patternLearningConfig.enabled) {
+    logger.info('Pattern learning enabled');
+  }
+
+  return registry;
+}
+
+function observeErrorForPatternLearning(
+  registry: ErrorPatternRegistry,
+  logger: Logger,
+  error: unknown,
+  providerHint?: string,
+): void {
+  void registry.learnFromError(error, providerHint).catch((learningError) => {
+    logger.debug('Pattern learning failed', {
+      error: learningError instanceof Error ? learningError.message : String(learningError),
+    });
+  });
 }
 
 // ============================================================================
@@ -219,13 +258,7 @@ export const RateLimitFallback: Plugin = async ({ client, directory, worktree })
       logger.info("Headless mode — will abort session on rate limit");
 
       // Minimal setup: only error pattern detection + abort
-      const errorPatternRegistry = new ErrorPatternRegistry(logger, config.errorPatterns?.ignorePatterns);
-      if (config.errorPatterns?.custom) {
-        errorPatternRegistry.replaceCustomPatterns(config.errorPatterns.custom);
-      }
-      if (config.errorPatterns?.learnedPatterns) {
-        errorPatternRegistry.updateLearnedPatterns(config.errorPatterns.learnedPatterns);
-      }
+      const errorPatternRegistry = initializeErrorPatternRegistry(config, configSource, logger);
 
       // Track sessions already aborted to avoid duplicate abort calls
       const abortedSessions = new Set<string>();
@@ -247,15 +280,27 @@ export const RateLimitFallback: Plugin = async ({ client, directory, worktree })
         event: async ({ event }) => {
           if (isSessionErrorEvent(event)) {
             const { sessionID, error } = event.properties;
-            if (sessionID && error && errorPatternRegistry.isRateLimitError(error)) {
-              await abortSession(sessionID, "session.error");
+            if (sessionID && error) {
+              const classification = errorPatternRegistry.classifyError(error);
+              if (classification !== 'ignored') {
+                observeErrorForPatternLearning(errorPatternRegistry, logger, error);
+              }
+              if (classification === 'rate-limit') {
+                await abortSession(sessionID, "session.error");
+              }
             }
           }
 
           if (isMessageUpdatedEvent(event)) {
             const info = event.properties.info;
-            if (info?.error && errorPatternRegistry.isRateLimitError(info.error)) {
-              await abortSession(info.sessionID, "message.updated");
+            if (info?.error) {
+              const classification = errorPatternRegistry.classifyError(info.error, info.providerID);
+              if (classification !== 'ignored') {
+                observeErrorForPatternLearning(errorPatternRegistry, logger, info.error, info.providerID);
+              }
+              if (classification === 'rate-limit') {
+                await abortSession(info.sessionID, "message.updated");
+              }
             }
           }
 
@@ -263,7 +308,12 @@ export const RateLimitFallback: Plugin = async ({ client, directory, worktree })
             const props = event.properties;
             const status = props?.status;
             if (status?.type === "retry" && status?.message) {
-              if (errorPatternRegistry.isRateLimitError({ message: status.message })) {
+              const statusError = { message: status.message };
+              const classification = errorPatternRegistry.classifyError(statusError);
+              if (classification !== 'ignored') {
+                observeErrorForPatternLearning(errorPatternRegistry, logger, statusError);
+              }
+              if (classification === 'rate-limit') {
                 await abortSession(props.sessionID, "session.status retry");
               }
             }
@@ -277,26 +327,7 @@ export const RateLimitFallback: Plugin = async ({ client, directory, worktree })
   }
 
   // Initialize error pattern registry
-  const errorPatternRegistry = new ErrorPatternRegistry(logger, config.errorPatterns?.ignorePatterns);
-  if (config.errorPatterns?.custom) {
-    errorPatternRegistry.replaceCustomPatterns(config.errorPatterns.custom);
-  }
-  if (config.errorPatterns?.learnedPatterns) {
-    errorPatternRegistry.updateLearnedPatterns(config.errorPatterns.learnedPatterns);
-  }
-
-  // Initialize pattern learning if enabled
-  if (config.errorPatterns?.enableLearning && configSource) {
-    const patternLearningConfig = {
-      enabled: config.errorPatterns.enableLearning,
-      autoApproveThreshold: config.errorPatterns.autoApproveThreshold ?? 0.8,
-      maxLearnedPatterns: config.errorPatterns.maxLearnedPatterns ?? 20,
-      minErrorFrequency: config.errorPatterns.minErrorFrequency ?? 3,
-      learningWindowMs: config.errorPatterns.learningWindowMs ?? 86400000,
-    };
-    errorPatternRegistry.initializePatternLearning(patternLearningConfig, configSource);
-    logger.info('Pattern learning enabled');
-  }
+  const errorPatternRegistry = initializeErrorPatternRegistry(config, configSource, logger);
 
   // Initialize health tracker
   let healthTracker: HealthTracker | undefined;
@@ -324,6 +355,7 @@ export const RateLimitFallback: Plugin = async ({ client, directory, worktree })
   const subagentTracker = new SubagentTracker(config);
 
   const metricsManager = new MetricsManager(config.metrics ?? { enabled: false, output: { console: true, format: "pretty" }, resetInterval: "daily" }, logger);
+  errorPatternRegistry.setPatternLearningMetricsSink(metricsManager);
 
   const fallbackHandler = new FallbackHandler(config, client, logger, metricsManager, subagentTracker, healthTracker);
 
@@ -382,15 +414,15 @@ export const RateLimitFallback: Plugin = async ({ client, directory, worktree })
       // Handle session.error events
       if (isSessionErrorEvent(event)) {
         const { sessionID, error } = event.properties;
-        if (sessionID && error && errorPatternRegistry.isRateLimitError(error)) {
-          // Learn from this error if pattern learning is enabled
-          const patternLearner = errorPatternRegistry.getPatternLearner();
-          if (patternLearner) {
-            patternLearner.processError(error).catch((err) => {
-              logger.debug('Pattern learning failed', { error: err });
-            });
+        if (sessionID && error) {
+          const providerHint = fallbackHandler.getSessionModel(sessionID)?.providerID;
+          const classification = errorPatternRegistry.classifyError(error, providerHint);
+          if (classification !== 'ignored') {
+            observeErrorForPatternLearning(errorPatternRegistry, logger, error, providerHint);
           }
-          await fallbackHandler.handleRateLimitFallback(sessionID, "", "");
+          if (classification === 'rate-limit') {
+            await fallbackHandler.handleRateLimitFallback(sessionID, "", "");
+          }
         }
       }
 
@@ -398,7 +430,7 @@ export const RateLimitFallback: Plugin = async ({ client, directory, worktree })
       if (isMessageUpdatedEvent(event)) {
         const info = event.properties.info;
         const errorClassification = info?.error
-          ? errorPatternRegistry.classifyError(info.error)
+          ? errorPatternRegistry.classifyError(info.error, info.providerID)
           : null;
 
         // Track model info for all assistant messages (needed to identify current model on session.error)
@@ -406,14 +438,12 @@ export const RateLimitFallback: Plugin = async ({ client, directory, worktree })
           fallbackHandler.setSessionModel(info.sessionID, info.providerID, info.modelID);
         }
 
+        if (info?.error && errorClassification !== 'ignored') {
+          const providerHint = info.providerID || fallbackHandler.getSessionModel(info.sessionID)?.providerID;
+          observeErrorForPatternLearning(errorPatternRegistry, logger, info.error, providerHint);
+        }
+
         if (info?.error && errorClassification === 'rate-limit') {
-          // Learn from this error if pattern learning is enabled
-          const patternLearner = errorPatternRegistry.getPatternLearner();
-          if (patternLearner) {
-            patternLearner.processError(info.error).catch((err) => {
-              logger.debug('Pattern learning failed', { error: err });
-            });
-          }
           await fallbackHandler.handleRateLimitFallback(info.sessionID, info.providerID || "", info.modelID || "");
         } else if (info?.status === "completed" && !info?.error && info?.id) {
           // Record fallback success
@@ -430,7 +460,13 @@ export const RateLimitFallback: Plugin = async ({ client, directory, worktree })
         const status = props?.status;
 
         if (status?.type === "retry" && status?.message) {
-          if (errorPatternRegistry.isRateLimitError({ message: status.message })) {
+          const statusError = { message: status.message };
+          const providerHint = fallbackHandler.getSessionModel(props.sessionID)?.providerID;
+          const classification = errorPatternRegistry.classifyError(statusError, providerHint);
+          if (classification !== 'ignored') {
+            observeErrorForPatternLearning(errorPatternRegistry, logger, statusError, providerHint);
+          }
+          if (classification === 'rate-limit') {
             // Try fallback on any attempt, handleRateLimitFallback will manage state
             await fallbackHandler.handleRateLimitFallback(props.sessionID, "", "");
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azumag/opencode-rate-limit-fallback",
-  "version": "1.70.8",
+  "version": "1.70.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azumag/opencode-rate-limit-fallback",
-      "version": "1.70.8",
+      "version": "1.70.9",
       "license": "MIT",
       "dependencies": {
         "@opencode-ai/plugin": "1.18.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azumag/opencode-rate-limit-fallback",
-  "version": "1.70.8",
+  "version": "1.70.9",
   "description": "OpenCode plugin that automatically switches to fallback models when rate limited",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/config/Validator.ts
+++ b/src/config/Validator.ts
@@ -576,6 +576,55 @@ export class ConfigValidator {
           }
         }
 
+        if (config.errorPatterns.enableLearning !== undefined &&
+            typeof config.errorPatterns.enableLearning !== 'boolean') {
+          errors.push({
+            path: 'errorPatterns.enableLearning',
+            message: 'enableLearning must be a boolean',
+            severity: 'error',
+            value: config.errorPatterns.enableLearning,
+          });
+        }
+
+        if (config.errorPatterns.autoApproveThreshold !== undefined &&
+            (typeof config.errorPatterns.autoApproveThreshold !== 'number' ||
+             !Number.isFinite(config.errorPatterns.autoApproveThreshold) ||
+             config.errorPatterns.autoApproveThreshold < 0 ||
+             config.errorPatterns.autoApproveThreshold > 1)) {
+          errors.push({
+            path: 'errorPatterns.autoApproveThreshold',
+            message: 'autoApproveThreshold must be a number between 0 and 1',
+            severity: 'error',
+            value: config.errorPatterns.autoApproveThreshold,
+          });
+        }
+
+        for (const [key, value] of [
+          ['maxLearnedPatterns', config.errorPatterns.maxLearnedPatterns],
+          ['minErrorFrequency', config.errorPatterns.minErrorFrequency],
+        ] as const) {
+          if (value !== undefined && (!Number.isInteger(value) || value < 1)) {
+            errors.push({
+              path: `errorPatterns.${key}`,
+              message: `${key} must be a positive integer`,
+              severity: 'error',
+              value,
+            });
+          }
+        }
+
+        if (config.errorPatterns.learningWindowMs !== undefined &&
+            (typeof config.errorPatterns.learningWindowMs !== 'number' ||
+             !Number.isFinite(config.errorPatterns.learningWindowMs) ||
+             config.errorPatterns.learningWindowMs <= 0)) {
+          errors.push({
+            path: 'errorPatterns.learningWindowMs',
+            message: 'learningWindowMs must be a positive finite number',
+            severity: 'error',
+            value: config.errorPatterns.learningWindowMs,
+          });
+        }
+
         if (config.errorPatterns.ignorePatterns !== undefined) {
           if (!Array.isArray(config.errorPatterns.ignorePatterns)) {
             errors.push({

--- a/src/config/Watcher.ts
+++ b/src/config/Watcher.ts
@@ -2,7 +2,8 @@
  * Configuration file watcher for hot reload functionality
  */
 
-import { watch, type FSWatcher } from 'fs';
+import { realpathSync, watch, type FSWatcher } from 'fs';
+import { basename, dirname } from 'path';
 import type { Logger } from '../../logger.js';
 
 /**
@@ -25,6 +26,7 @@ export class ConfigWatcher {
   private onReload: () => Promise<void>;
   private options: ConfigWatchOptions;
   private isReloading: boolean;
+  private pendingReload: boolean;
 
   constructor(
     configPath: string,
@@ -37,6 +39,7 @@ export class ConfigWatcher {
     this.onReload = onReload;
     this.options = options;
     this.isReloading = false;
+    this.pendingReload = false;
   }
 
   /**
@@ -54,17 +57,22 @@ export class ConfigWatcher {
     }
 
     try {
-      this.watcher = watch(this.configPath, (eventType, filename) => {
+      let watchedPath = this.configPath;
+      try {
+        watchedPath = realpathSync(this.configPath);
+      } catch {
+        // Fall back to the configured path when it cannot be resolved yet.
+      }
+      const watchedFile = basename(watchedPath);
+      // Watch the parent directory so atomic replacement of the config file
+      // or a symlink target does not leave the watcher on the old inode.
+      this.watcher = watch(dirname(watchedPath), (eventType, filename) => {
+        if (filename && basename(filename.toString()) !== watchedFile) {
+          return;
+        }
         this.logger.debug(`Config file event: ${eventType} ${filename || ''}`);
 
-        // Debounce the reload
-        if (this.debounceTimer) {
-          clearTimeout(this.debounceTimer);
-        }
-
-        this.debounceTimer = setTimeout(() => {
-          this.handleConfigChange();
-        }, this.options.debounceMs);
+        this.scheduleReload();
       });
 
       this.logger.info(`Watching config file for changes: ${this.configPath}`);
@@ -79,6 +87,7 @@ export class ConfigWatcher {
    * Stop watching the config file
    */
   stop(): void {
+    this.pendingReload = false;
     if (this.debounceTimer) {
       clearTimeout(this.debounceTimer);
       this.debounceTimer = undefined;
@@ -102,7 +111,8 @@ export class ConfigWatcher {
    */
   private async handleConfigChange(): Promise<void> {
     if (this.isReloading) {
-      this.logger.warn('Config changed while reload in progress, changes will be picked up after current reload completes');
+      this.pendingReload = true;
+      this.logger.warn('Config changed while reload in progress, queued for after current reload completes');
       return;
     }
 
@@ -117,7 +127,21 @@ export class ConfigWatcher {
       this.logger.error('Config reload failed', { error: errorMessage });
     } finally {
       this.isReloading = false;
+      if (this.pendingReload) {
+        this.pendingReload = false;
+        this.scheduleReload();
+      }
     }
+  }
+
+  private scheduleReload(): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = undefined;
+      void this.handleConfigChange();
+    }, this.options.debounceMs);
   }
 
   /**

--- a/src/diagnostics/Reporter.ts
+++ b/src/diagnostics/Reporter.ts
@@ -4,7 +4,7 @@
  */
 
 import { Logger } from '../../logger.js';
-import type { PluginConfig, ModelHealth, LearnedPattern } from '../types/index.js';
+import type { PluginConfig, ModelHealth, LearnedPattern, PatternLearningStats } from '../types/index.js';
 import type { HealthTracker } from '../health/HealthTracker.js';
 import type { CircuitBreaker } from '../circuitbreaker/index.js';
 import { ErrorPatternRegistry } from '../errors/PatternRegistry.js';
@@ -65,6 +65,10 @@ export interface DiagnosticReport {
       byPriority: Record<string, number>;
     };
     learnedPatterns: LearnedPattern[];
+    learning: {
+      enabled: boolean;
+      stats: PatternLearningStats;
+    };
   };
   circuitBreaker: {
     enabled: boolean;
@@ -162,9 +166,19 @@ export class DiagnosticReporter {
    * Generate error pattern registry report
    */
   private generateErrorPatternsReport() {
+    const patternLearner = this.errorPatternRegistry.getPatternLearner();
     return {
       stats: this.errorPatternRegistry.getStats(),
       learnedPatterns: this.errorPatternRegistry.getLearnedPatterns(),
+      learning: {
+        enabled: this.errorPatternRegistry.isLearningEnabled(),
+        stats: patternLearner?.getStats() ?? {
+          totalErrorsProcessed: 0,
+          patternsLearned: 0,
+          patternsRejected: 0,
+          persistenceFailures: 0,
+        },
+      },
     };
   }
 
@@ -314,6 +328,11 @@ export class DiagnosticReporter {
     lines.push(`Total Patterns: ${patternStats.total}`);
     lines.push(`Default Patterns: ${patternStats.default || 0}`);
     lines.push(`Learned Patterns: ${patternStats.learned || 0}`);
+    lines.push(`Learning Enabled: ${report.errorPatterns.learning.enabled ? 'Yes' : 'No'}`);
+    lines.push(`Learning Errors Processed: ${report.errorPatterns.learning.stats.totalErrorsProcessed}`);
+    lines.push(`Learning Accepted: ${report.errorPatterns.learning.stats.patternsLearned}`);
+    lines.push(`Learning Rejected: ${report.errorPatterns.learning.stats.patternsRejected}`);
+    lines.push(`Learning Persistence Failures: ${report.errorPatterns.learning.stats.persistenceFailures}`);
     lines.push('');
 
     if (Object.keys(patternStats.byProvider).length > 0) {

--- a/src/errors/PatternExtractor.ts
+++ b/src/errors/PatternExtractor.ts
@@ -29,20 +29,41 @@ const STATUS_CODE_PATTERNS = [
  * Pre-defined rate limit phrase patterns
  */
 const RATE_LIMIT_PHRASE_PATTERNS = [
-  /(?:rate.?limit|quota|exceed|too.?many.?requests|throttl)/gi,
+  /\b(?:rate[ _-]?limit(?:ed)?|quota[ _-](?:exceeded|exhausted)|too[ _-]?many[ _-]?requests|throttl(?:e|ed|ing)|resource[ _-]?exhausted|(?:daily|request)[ _-]limit[ _-](?:exceeded|reached|exhausted))\b/gi,
 ] as const;
 
 /**
  * Pre-defined API error code patterns
  */
 const ERROR_CODE_PATTERNS = [
-  /\b(?:insufficient_quota|resource_exhausted|rate_limit_error|quota_exceeded|over_quota)\b/gi,
+  /\b(?:[a-z0-9]+[_-])*(?:rate[_-]?limit|quota|throttl(?:e|ed|ing)?|resource[_-]exhausted|too[_-]many[_-]requests)(?:[_-][a-z0-9]+)*\b/gi,
 ] as const;
 
 /**
  * Minimum length for pattern strings
  */
 const MIN_PATTERN_LENGTH = 3;
+
+const QUOTA_DEPLETION_TOKENS = new Set([
+  'depleted',
+  'exceeded',
+  'exhausted',
+  'insufficient',
+  'over',
+  'reached',
+  'spent',
+]);
+
+function containsIdentifier(text: string, identifier: string): boolean {
+  const escaped = identifier.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`(^|[^a-z0-9_-])${escaped}([^a-z0-9_-]|$)`, 'i').test(text);
+}
+
+function hasQuotaDepletionSemantics(code: string): boolean {
+  const tokens = code.split(/[_-]+/);
+  return !tokens.includes('quota') ||
+    tokens.some(token => QUOTA_DEPLETION_TOKENS.has(token));
+}
 
 /**
  * Pattern Extractor class
@@ -98,11 +119,16 @@ export class PatternExtractor {
   /**
    * Extract provider ID from error text
    */
-  private extractProvider(textSources: string[]): string | null {
+  private extractProvider(textSources: string[], providerHint?: string): string | null {
+    const normalizedHint = providerHint?.trim().toLowerCase();
+    if (normalizedHint) {
+      return normalizedHint;
+    }
+
     for (const text of textSources) {
       const lowerText = text.toLowerCase();
       for (const provider of KNOWN_PROVIDERS) {
-        if (lowerText.includes(provider)) {
+        if (containsIdentifier(lowerText, provider)) {
           return provider;
         }
       }
@@ -144,14 +170,15 @@ export class PatternExtractor {
       'too many requests',
       'quota exceeded',
       'rate limit exceeded',
-      'quota limit',
       'insufficient quota',
       'rate limited',
       'rate-limited',
       'throttled',
       'resource exhausted',
-      'daily limit',
-      'request limit',
+      'daily limit exceeded',
+      'daily limit reached',
+      'request limit exceeded',
+      'request limit reached',
     ];
 
     for (const text of lowerTextSources) {
@@ -175,21 +202,6 @@ export class PatternExtractor {
       }
     }
 
-    // Extract error codes (these go in errorCodes, not phrases)
-    // But we also add them to phrases for now
-    for (const text of lowerTextSources) {
-      for (const pattern of ERROR_CODE_PATTERNS) {
-        pattern.lastIndex = 0;
-        const matches = text.matchAll(pattern);
-        for (const match of matches) {
-          const errorCode = match[0].toLowerCase();
-          if (errorCode.length >= MIN_PATTERN_LENGTH) {
-            phrases.add(errorCode);
-          }
-        }
-      }
-    }
-
     return Array.from(phrases);
   }
 
@@ -205,7 +217,12 @@ export class PatternExtractor {
         const matches = text.matchAll(pattern);
         for (const match of matches) {
           const code = match[0].toLowerCase();
-          errorCodes.add(code);
+          // Structured error codes have separators. Plain words such as
+          // "quota" are too broad to become future detection patterns.
+          if ((code.includes('_') || code.includes('-')) &&
+              hasQuotaDepletionSemantics(code)) {
+            errorCodes.add(code);
+          }
         }
       }
     }
@@ -216,7 +233,7 @@ export class PatternExtractor {
   /**
    * Extract pattern candidates from an error
    */
-  extractPattern(error: unknown): PatternCandidate | null {
+  extractPattern(error: unknown, providerHint?: string): PatternCandidate | null {
     if (!this.isValidErrorObject(error)) {
       return null;
     }
@@ -226,7 +243,7 @@ export class PatternExtractor {
       return null;
     }
 
-    const provider = this.extractProvider(textSources);
+    const provider = this.extractProvider(textSources, providerHint);
     const statusCodes = this.extractStatusCodes(textSources);
     const phrases = this.extractPhrases(textSources);
     const errorCodes = this.extractErrorCodes(textSources);

--- a/src/errors/PatternLearner.ts
+++ b/src/errors/PatternLearner.ts
@@ -2,7 +2,14 @@
  * Pattern Learner for orchestrating error pattern learning
  */
 
-import type { ErrorPattern, LearnedPattern, PatternLearningConfig, PatternCandidate } from '../types/index.js';
+import type {
+  ErrorPattern,
+  LearnedPattern,
+  PatternLearningConfig,
+  PatternCandidate,
+  PatternLearningMetricsSink,
+  PatternLearningStats,
+} from '../types/index.js';
 import { PatternExtractor } from './PatternExtractor.js';
 import { ConfidenceScorer } from './ConfidenceScorer.js';
 import { PatternStorage } from './PatternStorage.js';
@@ -15,8 +22,9 @@ interface PatternTracking {
   pattern: ErrorPattern;
   frequency: number;
   firstSeen: number;
-  samples: string[];
 }
+
+type PatternsUpdatedCallback = (patterns: readonly LearnedPattern[]) => void;
 
 /**
  * Pattern Learner class
@@ -28,26 +36,39 @@ export class PatternLearner {
   private storage: PatternStorage;
   private config: PatternLearningConfig;
   private logger: Logger;
+  private metricsSink?: PatternLearningMetricsSink;
+  private onPatternsUpdated?: PatternsUpdatedCallback;
 
   // Track patterns being learned
   private patternTracking: Map<string, PatternTracking>;
+  private pendingPatternKeys: Set<string>;
+  private saveQueue: Promise<void> = Promise.resolve();
 
   // Statistics
-  private stats = {
+  private stats: PatternLearningStats = {
     totalErrorsProcessed: 0,
     patternsLearned: 0,
     patternsRejected: 0,
+    persistenceFailures: 0,
   };
 
   /**
    * Constructor
    */
-  constructor(config: PatternLearningConfig, logger?: Logger) {
+  constructor(
+    config: PatternLearningConfig,
+    logger?: Logger,
+    onPatternsUpdated?: PatternsUpdatedCallback,
+    metricsSink?: PatternLearningMetricsSink,
+  ) {
     this.config = config;
     this.extractor = new PatternExtractor();
     this.scorer = new ConfidenceScorer(config);
     this.storage = new PatternStorage(config);
     this.patternTracking = new Map();
+    this.pendingPatternKeys = new Set();
+    this.onPatternsUpdated = onPatternsUpdated;
+    this.metricsSink = metricsSink;
 
     this.logger = logger || {
       debug: () => {},
@@ -73,20 +94,36 @@ export class PatternLearner {
     this.storage.setConfigFilePath(path);
   }
 
+  setMetricsSink(metricsSink?: PatternLearningMetricsSink): void {
+    this.metricsSink = metricsSink;
+  }
+
   /**
    * Process an error and learn from it
    */
-  async processError(error: unknown): Promise<LearnedPattern | null> {
+  async processError(
+    error: unknown,
+    providerHint?: string,
+    existingPatterns: ErrorPattern[] = [],
+  ): Promise<LearnedPattern | null> {
     if (!this.config.enabled) {
       this.logger.debug('Pattern learning is disabled, skipping');
       return null;
     }
 
     this.stats.totalErrorsProcessed++;
+    this.metricsSink?.recordPatternErrorProcessed();
 
     // Extract pattern from error
-    const candidate = this.extractor.extractPattern(error);
+    const candidate = this.extractor.extractPattern(error, providerHint);
     if (!candidate) {
+      return null;
+    }
+
+    // Server errors alone are not evidence of rate limiting. Require an
+    // explicit rate-limit signal or HTTP 429 before tracking a candidate.
+    if (candidate.statusCode !== '429' &&
+        candidate.phrases.length === 0 && candidate.errorCodes.length === 0) {
       return null;
     }
 
@@ -98,11 +135,21 @@ export class PatternLearner {
 
     // Create a pattern key for tracking
     const patternKey = this.createPatternKey(candidate);
+    if (this.pendingPatternKeys.has(patternKey)) {
+      return null;
+    }
 
     // Update pattern tracking
-    const tracking = this.getOrCreateTracking(candidate, patternKey);
+    const now = Date.now();
+    this.pruneExpiredTracking(now);
+    const tracking = this.getOrCreateTracking(candidate, patternKey, now);
+    if (!tracking) {
+      this.stats.patternsRejected++;
+      this.metricsSink?.recordPatternRejected();
+      this.logger.debug('Pattern tracking capacity reached, dropping candidate');
+      return null;
+    }
     tracking.frequency++;
-    tracking.samples.push(candidate.rawText);
 
     // Check if we should learn this pattern
     if (tracking.frequency < this.config.minErrorFrequency) {
@@ -114,12 +161,15 @@ export class PatternLearner {
       tracking.pattern,
       tracking.frequency,
       tracking.firstSeen,
-      []
+      existingPatterns.filter(pattern =>
+        !pattern.provider || pattern.provider.trim().toLowerCase() === candidate.provider),
     );
 
     // Check if we should learn and save this pattern
     if (!this.scorer.shouldAutoApprove(confidence)) {
       this.stats.patternsRejected++;
+      this.metricsSink?.recordPatternRejected();
+      this.patternTracking.delete(patternKey);
       this.logger.debug(`Pattern confidence ${confidence} below threshold ${this.config.autoApproveThreshold}`);
       return null;
     }
@@ -131,13 +181,25 @@ export class PatternLearner {
       tracking.frequency
     );
 
-    // Save to storage
-    await this.saveLearnedPattern(learnedPattern);
+    this.pendingPatternKeys.add(patternKey);
+    try {
+      await this.saveLearnedPattern(learnedPattern);
+    } catch (error) {
+      this.stats.persistenceFailures++;
+      this.metricsSink?.recordPatternPersistenceFailure();
+      this.logger.warn('Failed to persist learned pattern', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    } finally {
+      this.pendingPatternKeys.delete(patternKey);
+    }
 
     // Clear tracking for this pattern
     this.patternTracking.delete(patternKey);
 
     this.stats.patternsLearned++;
+    this.metricsSink?.recordPatternLearned(confidence);
     this.logger.info(`Learned new pattern: ${learnedPattern.name} with confidence ${confidence}`);
 
     return learnedPattern;
@@ -155,17 +217,27 @@ export class PatternLearner {
   /**
    * Save learned patterns
    */
-  async saveLearnedPatterns(patterns: LearnedPattern[]): Promise<void> {
+  async saveLearnedPatterns(patterns: LearnedPattern[]): Promise<LearnedPattern[]> {
+    return this.enqueueSave(() => this.persistPatterns(patterns));
+  }
+
+  private async persistPatterns(patterns: LearnedPattern[]): Promise<LearnedPattern[]> {
     const merged = this.storage.mergeSimilarPatterns(patterns);
     const cleaned = this.storage.cleanupPatterns(merged);
-    await this.storage.saveLearnedPatterns(cleaned);
+    const persisted = await this.storage.saveLearnedPatterns(cleaned);
+    if (this.storage.hasConfigFilePath() && !persisted) {
+      throw new Error('Failed to write learned patterns to the configuration file');
+    }
+
+    this.onPatternsUpdated?.(cleaned);
     this.logger.debug(`Saved ${cleaned.length} learned patterns`);
+    return cleaned;
   }
 
   /**
    * Get statistics
    */
-  getStats(): typeof PatternLearner.prototype.stats {
+  getStats(): PatternLearningStats {
     return { ...this.stats };
   }
 
@@ -177,6 +249,7 @@ export class PatternLearner {
       totalErrorsProcessed: 0,
       patternsLearned: 0,
       patternsRejected: 0,
+      persistenceFailures: 0,
     };
   }
 
@@ -194,7 +267,8 @@ export class PatternLearner {
     const parts = [
       candidate.provider || 'unknown',
       candidate.statusCode || 'no-status',
-      ...candidate.phrases.slice(0, 3), // Use first 3 phrases for key
+      ...[...candidate.errorCodes].sort(),
+      ...[...candidate.phrases].sort(),
     ].join('|');
     return parts;
   }
@@ -202,20 +276,37 @@ export class PatternLearner {
   /**
    * Get or create pattern tracking
    */
-  private getOrCreateTracking(candidate: PatternCandidate, patternKey: string): PatternTracking {
-    if (this.patternTracking.has(patternKey)) {
-      return this.patternTracking.get(patternKey)!;
+  private getOrCreateTracking(
+    candidate: PatternCandidate,
+    patternKey: string,
+    now: number,
+  ): PatternTracking | null {
+    const existingTracking = this.patternTracking.get(patternKey);
+    if (existingTracking) {
+      // Refresh insertion order so the map also acts as an LRU queue.
+      this.patternTracking.delete(patternKey);
+      this.patternTracking.set(patternKey, existingTracking);
+      return existingTracking;
+    }
+
+    if (!this.ensureTrackingCapacity()) {
+      return null;
     }
 
     // Create pattern from candidate
-    const allPatterns = [
-      ...candidate.phrases,
+    const allPatterns = [...new Set([
       ...candidate.errorCodes,
-      ...(candidate.statusCode ? [candidate.statusCode] : []),
-    ];
+      ...candidate.phrases,
+      // A 429 is independently meaningful. Other server statuses are only
+      // context and would make the learned OR-pattern dangerously broad.
+      ...(candidate.statusCode === '429' ? [candidate.statusCode] : []),
+    ])];
+    const signature = candidate.errorCodes[0] ?? candidate.phrases[0] ?? candidate.statusCode ?? 'rate-limit';
+    const providerSlug = (candidate.provider || 'unknown').replace(/[^a-z0-9_-]+/gi, '-').slice(0, 40);
+    const signatureSlug = signature.replace(/[^a-z0-9_-]+/gi, '-').slice(0, 50);
 
     const pattern: ErrorPattern = {
-      name: `learned-${candidate.provider}-${Date.now()}`,
+      name: `learned-${providerSlug}-${signatureSlug}-${now}`,
       provider: candidate.provider || undefined,
       patterns: allPatterns,
       priority: 70, // Medium priority for learned patterns
@@ -224,8 +315,7 @@ export class PatternLearner {
     const tracking: PatternTracking = {
       pattern,
       frequency: 0,
-      firstSeen: Date.now(),
-      samples: [],
+      firstSeen: now,
     };
 
     this.patternTracking.set(patternKey, tracking);
@@ -236,13 +326,41 @@ export class PatternLearner {
    * Save a single learned pattern
    */
   private async saveLearnedPattern(pattern: LearnedPattern): Promise<void> {
-    // Load existing patterns
-    const existing = await this.storage.loadLearnedPatterns();
+    await this.enqueueSave(async () => {
+      const savedPatterns = await this.storage.appendLearnedPatterns([pattern]);
+      if (!savedPatterns) {
+        throw new Error('Failed to write learned patterns to the configuration file');
+      }
+      this.onPatternsUpdated?.(savedPatterns);
+      this.logger.debug(`Saved ${savedPatterns.length} learned patterns`);
+    });
+  }
 
-    // Add new pattern
-    existing.push(pattern);
+  private enqueueSave<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.saveQueue.then(operation);
+    this.saveQueue = result.then(() => undefined, () => undefined);
+    return result;
+  }
 
-    // Merge and clean up
-    await this.saveLearnedPatterns(existing);
+  private pruneExpiredTracking(now: number): void {
+    for (const [key, tracking] of this.patternTracking.entries()) {
+      if (now - tracking.firstSeen > this.config.learningWindowMs &&
+          !this.pendingPatternKeys.has(key)) {
+        this.patternTracking.delete(key);
+      }
+    }
+  }
+
+  private ensureTrackingCapacity(): boolean {
+    const limit = Math.min(1000, Math.max(100, this.config.maxLearnedPatterns * 20));
+    while (this.patternTracking.size >= limit) {
+      const oldestEvictableKey = [...this.patternTracking.keys()]
+        .find(key => !this.pendingPatternKeys.has(key));
+      if (!oldestEvictableKey) {
+        return false;
+      }
+      this.patternTracking.delete(oldestEvictableKey);
+    }
+    return true;
   }
 }

--- a/src/errors/PatternRegistry.ts
+++ b/src/errors/PatternRegistry.ts
@@ -2,13 +2,28 @@
  * Error Pattern Registry for rate limit error detection
  */
 
-import type { ErrorPattern, LearnedPattern, PatternLearningConfig } from '../types/index.js';
+import type {
+  ErrorPattern,
+  LearnedPattern,
+  PatternLearningConfig,
+  PatternLearningMetricsSink,
+} from '../types/index.js';
 import type { Logger } from '../../logger.js';
-import { DEFAULT_ERROR_PATTERNS_CONFIG } from '../config/defaults.js';
+import {
+  DEFAULT_ERROR_PATTERNS_CONFIG,
+  DEFAULT_PATTERN_LEARNING_CONFIG,
+} from '../config/defaults.js';
 import { isValidErrorPattern, isValidLearnedPattern } from '../config/patternValidation.js';
 import { PatternLearner } from './PatternLearner.js';
 
 export type ErrorClassification = 'rate-limit' | 'ignored' | 'other';
+
+const MIN_LEARNED_PATTERN_CONFIDENCE = 0.7;
+
+function normalizeProvider(provider?: string): string | undefined {
+  const normalized = provider?.trim().toLowerCase();
+  return normalized || undefined;
+}
 
 /**
  * Error Pattern Registry class
@@ -22,6 +37,7 @@ export class ErrorPatternRegistry {
   private overriddenPatterns = new Map<string, ErrorPattern>();
   private patternLearner: PatternLearner | null = null;
   private learningConfig: PatternLearningConfig | null = null;
+  private patternLearningMetricsSink?: PatternLearningMetricsSink;
   // Logger is available for future use
   // @ts-ignore - Unused but kept for potential future use
   private _logger: Logger;
@@ -93,7 +109,6 @@ export class ErrorPatternRegistry {
         'rate limit exceeded',
         'user rate limit exceeded',
         'daily limit exceeded',
-        '429',
       ],
       priority: 80,
     });
@@ -200,9 +215,15 @@ export class ErrorPatternRegistry {
    */
   configurePatternLearning(config: PatternLearningConfig, configFilePath?: string): void {
     this.learningConfig = { ...config };
+    this.learnedPatterns = this.limitLearnedPatterns(this.learnedPatterns);
 
     if (!this.patternLearner && config.enabled) {
-      this.patternLearner = new PatternLearner(config, this._logger);
+      this.patternLearner = new PatternLearner(
+        config,
+        this._logger,
+        patterns => this.updateLearnedPatterns([...patterns]),
+        this.patternLearningMetricsSink,
+      );
     } else if (this.patternLearner) {
       this.patternLearner.updateConfig(config);
     }
@@ -226,6 +247,23 @@ export class ErrorPatternRegistry {
     return this.patternLearner;
   }
 
+  setPatternLearningMetricsSink(metricsSink?: PatternLearningMetricsSink): void {
+    this.patternLearningMetricsSink = metricsSink;
+    this.patternLearner?.setMetricsSink(metricsSink);
+  }
+
+  async learnFromError(error: unknown, providerHint?: string): Promise<LearnedPattern | null> {
+    if (!this.isLearningEnabled() || !this.patternLearner) {
+      return null;
+    }
+
+    const activePatterns = this.getAllPatterns().filter(pattern => {
+      const confidence = (pattern as Partial<LearnedPattern>).confidence;
+      return confidence === undefined || confidence > MIN_LEARNED_PATTERN_CONFIDENCE;
+    });
+    return this.patternLearner.processError(error, providerHint, activePatterns);
+  }
+
   /**
    * Add a learned pattern
    */
@@ -242,6 +280,7 @@ export class ErrorPatternRegistry {
     } else {
       this.learnedPatterns.push(pattern);
     }
+    this.learnedPatterns = this.limitLearnedPatterns(this.learnedPatterns);
   }
 
   /**
@@ -262,34 +301,50 @@ export class ErrorPatternRegistry {
    * Update learned patterns
    */
   updateLearnedPatterns(patterns: LearnedPattern[]): void {
-    this.learnedPatterns = Array.isArray(patterns)
+    this.learnedPatterns = this.limitLearnedPatterns(patterns);
+  }
+
+  private limitLearnedPatterns(patterns: readonly LearnedPattern[]): LearnedPattern[] {
+    const validPatterns = Array.isArray(patterns)
       ? patterns.filter(isValidLearnedPattern)
       : [];
+    const configuredLimit = this.learningConfig?.maxLearnedPatterns ??
+      DEFAULT_PATTERN_LEARNING_CONFIG.maxLearnedPatterns;
+    const limit = Math.max(1, Math.floor(configuredLimit));
+
+    return [...validPatterns]
+      .sort((a, b) => {
+        if (a.confidence !== b.confidence) {
+          return b.confidence - a.confidence;
+        }
+        return b.sampleCount - a.sampleCount;
+      })
+      .slice(0, limit);
   }
 
   /**
    * Check if an error matches any registered rate limit pattern
    */
-  isRateLimitError(error: unknown): boolean {
-    return this.classifyError(error) === 'rate-limit';
+  isRateLimitError(error: unknown, providerHint?: string): boolean {
+    return this.classifyError(error, providerHint) === 'rate-limit';
   }
 
   /**
    * Classify an error so ignored notices are not counted as model failures.
    */
-  classifyError(error: unknown): ErrorClassification {
-    return this.analyzeError(error).classification;
+  classifyError(error: unknown, providerHint?: string): ErrorClassification {
+    return this.analyzeError(error, providerHint).classification;
   }
 
   /**
    * Get the matched pattern for an error, or null if no match
    * Checks default patterns first, then learned patterns
    */
-  getMatchedPattern(error: unknown): ErrorPattern | null {
-    return this.analyzeError(error).pattern;
+  getMatchedPattern(error: unknown, providerHint?: string): ErrorPattern | null {
+    return this.analyzeError(error, providerHint).pattern;
   }
 
-  private analyzeError(error: unknown): { classification: ErrorClassification; pattern: ErrorPattern | null } {
+  private analyzeError(error: unknown, providerHint?: string): { classification: ErrorClassification; pattern: ErrorPattern | null } {
     if (!error || typeof error !== 'object') {
       return { classification: 'other', pattern: null };
     }
@@ -312,6 +367,7 @@ export class ErrorPatternRegistry {
 
     // Combine all text sources for matching
     const allText = [responseBody, message, name, statusCode].join(' ').toLowerCase();
+    const normalizedProvider = normalizeProvider(providerHint) || this.inferProvider(allText);
 
     const hasStrongRateLimitSignal = this.hasStrongRateLimitSignal(allText);
     if (!hasStrongRateLimitSignal && this.matchesIgnorePattern(allText)) {
@@ -320,6 +376,13 @@ export class ErrorPatternRegistry {
 
     // Check each pattern in default patterns first
     for (const pattern of this.patterns) {
+      if (pattern.provider) {
+        const isCustomPattern = this.customPatternNames.has(pattern.name);
+        if ((normalizedProvider && normalizeProvider(pattern.provider) !== normalizedProvider) ||
+            (!normalizedProvider && isCustomPattern)) {
+          continue;
+        }
+      }
       for (const patternStr of pattern.patterns) {
         if (this.matchesPattern(patternStr, allText)) {
           return { classification: 'rate-limit', pattern };
@@ -329,8 +392,13 @@ export class ErrorPatternRegistry {
 
     // Check learned patterns
     for (const pattern of this.learnedPatterns) {
+      if (pattern.confidence <= MIN_LEARNED_PATTERN_CONFIDENCE ||
+          (pattern.provider && normalizeProvider(pattern.provider) !== normalizedProvider)) {
+        continue;
+      }
       for (const patternStr of pattern.patterns) {
         if (this.matchesPattern(patternStr, allText)) {
+          this.patternLearningMetricsSink?.recordLearnedPatternMatch();
           return { classification: 'rate-limit', pattern };
         }
       }
@@ -350,7 +418,9 @@ export class ErrorPatternRegistry {
    * Get patterns for a specific provider
    */
   getPatternsForProvider(provider: string): ErrorPattern[] {
-    return this.patterns.filter(p => !p.provider || p.provider === provider);
+    const normalizedProvider = normalizeProvider(provider);
+    return this.patterns.filter(pattern =>
+      !pattern.provider || normalizeProvider(pattern.provider) === normalizedProvider);
   }
 
   /**
@@ -398,7 +468,7 @@ export class ErrorPatternRegistry {
 
     for (const pattern of [...this.patterns, ...this.learnedPatterns]) {
       // Count by provider
-      const provider = pattern.provider || 'generic';
+      const provider = normalizeProvider(pattern.provider) || 'generic';
       byProvider[provider] = (byProvider[provider] || 0) + 1;
 
       // Count by priority range
@@ -437,6 +507,18 @@ export class ErrorPatternRegistry {
 
   private hasStrongRateLimitSignal(text: string): boolean {
     return this.matchesPattern(/\b429\b/i, text) || this.matchesPattern('rate_limit_error', text);
+  }
+
+  private inferProvider(text: string): string | undefined {
+    const providers = new Set(
+      [...this.patterns, ...this.learnedPatterns]
+        .map(pattern => normalizeProvider(pattern.provider))
+        .filter((provider): provider is string => Boolean(provider)),
+    );
+    return [...providers].find(provider => {
+      const escapedProvider = provider.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      return new RegExp(`(^|[^a-z0-9_-])${escapedProvider}([^a-z0-9_-]|$)`, 'i').test(text);
+    });
   }
 
   private matchesPattern(pattern: string | RegExp, text: string): boolean {

--- a/src/errors/PatternStorage.ts
+++ b/src/errors/PatternStorage.ts
@@ -4,7 +4,19 @@
 
 import type { LearnedPattern, PatternLearningConfig, ErrorPattern } from '../types/index.js';
 import { calculateJaccardSimilarity } from '../utils/similarity.js';
+import { isValidLearnedPattern } from '../config/patternValidation.js';
 import * as fs from 'fs/promises';
+import { basename, dirname, join } from 'path';
+
+const LOCK_RETRY_DELAY_MS = 25;
+const LOCK_MAX_ATTEMPTS = 200;
+const LOCK_STALE_MS = 30000;
+
+interface ConfigLock {
+  handle: fs.FileHandle;
+  lockPath: string;
+  token: string;
+}
 
 /**
  * Pattern Storage class
@@ -33,6 +45,10 @@ export class PatternStorage {
    */
   setConfigFilePath(path: string): void {
     this.configFilePath = path;
+  }
+
+  hasConfigFilePath(): boolean {
+    return this.configFilePath !== null;
   }
 
   /**
@@ -67,6 +83,10 @@ export class PatternStorage {
         }
 
         const otherPattern = patterns[j];
+        if ((currentPattern.provider?.trim().toLowerCase() ?? null) !==
+            (otherPattern.provider?.trim().toLowerCase() ?? null)) {
+          continue;
+        }
         const currentStr = currentPattern.patterns.map(p => String(p)).join(' ');
         const otherStr = otherPattern.patterns.map(p => String(p)).join(' ');
 
@@ -126,30 +146,45 @@ export class PatternStorage {
   /**
    * Save learned patterns to config file
    */
-  async saveLearnedPatterns(patterns: LearnedPattern[]): Promise<void> {
-    if (!this.configFilePath) {
-      return; // No config file set, skip saving
+  async saveLearnedPatterns(patterns: LearnedPattern[]): Promise<boolean> {
+    const targetPath = await this.resolveConfigFilePath();
+    if (!targetPath) {
+      return false;
     }
 
     try {
-      // Read the existing config
-      const configData = JSON.parse(await fs.readFile(this.configFilePath, 'utf-8'));
+      return await this.withConfigLock(targetPath, async () => {
+        const configData = await this.readConfigData(targetPath);
+        await this.writeConfigData(targetPath, configData, patterns);
+        return true;
+      });
+    } catch {
+      return false;
+    }
+  }
 
-      // Update the learned patterns
-      if (!configData.errorPatterns) {
-        configData.errorPatterns = {};
-      }
-      configData.errorPatterns.learnedPatterns = patterns;
+  /**
+   * Add patterns with a lock-protected read-modify-write transaction.
+   */
+  async appendLearnedPatterns(patterns: LearnedPattern[]): Promise<LearnedPattern[] | null> {
+    const validIncoming = patterns.filter(isValidLearnedPattern);
+    const targetPath = await this.resolveConfigFilePath();
+    if (!targetPath) {
+      return this.cleanupPatterns(this.mergeSimilarPatterns(validIncoming));
+    }
 
-      // Write back to file
-      await fs.writeFile(
-        this.configFilePath,
-        JSON.stringify(configData, null, 2),
-        'utf-8'
-      );
-    } catch (error) {
-      // Silently handle save errors - pattern learning is a best-effort feature
-      // Errors will be logged by the caller if needed
+    try {
+      return await this.withConfigLock(targetPath, async () => {
+        const configData = await this.readConfigData(targetPath);
+        const existing = this.extractLearnedPatterns(configData);
+        const finalPatterns = this.cleanupPatterns(
+          this.mergeSimilarPatterns([...existing, ...validIncoming]),
+        );
+        await this.writeConfigData(targetPath, configData, finalPatterns);
+        return finalPatterns;
+      });
+    } catch {
+      return null;
     }
   }
 
@@ -157,51 +192,17 @@ export class PatternStorage {
    * Validate and load learned patterns from config
    */
   async loadLearnedPatterns(): Promise<LearnedPattern[]> {
-    if (!this.configFilePath) {
+    const targetPath = await this.resolveConfigFilePath();
+    if (!targetPath) {
       return [];
     }
 
     try {
-      const configData = JSON.parse(await fs.readFile(this.configFilePath, 'utf-8'));
-      const learnedPatterns = configData.errorPatterns?.learnedPatterns;
-
-      if (!Array.isArray(learnedPatterns)) {
-        return [];
-      }
-
-      // Validate each pattern
-      const validPatterns: LearnedPattern[] = [];
-      for (const pattern of learnedPatterns) {
-        if (this.isValidLearnedPattern(pattern)) {
-          validPatterns.push(pattern);
-        }
-      }
-
-      return validPatterns;
+      return this.extractLearnedPatterns(await this.readConfigData(targetPath));
     } catch {
       // File doesn't exist or is invalid
       return [];
     }
-  }
-
-  /**
-   * Validate a learned pattern object
-   */
-  private isValidLearnedPattern(pattern: unknown): pattern is LearnedPattern {
-    if (!pattern || typeof pattern !== 'object') {
-      return false;
-    }
-
-    const p = pattern as Record<string, unknown>;
-    return (
-      typeof p.name === 'string' &&
-      typeof p.confidence === 'number' &&
-      typeof p.learnedAt === 'string' &&
-      typeof p.sampleCount === 'number' &&
-      typeof p.priority === 'number' &&
-      Array.isArray(p.patterns) &&
-      p.patterns.every((pt: unknown) => typeof pt === 'string' || pt instanceof RegExp)
-    );
   }
 
   /**
@@ -218,5 +219,132 @@ export class PatternStorage {
       learnedAt: new Date().toISOString(),
       sampleCount,
     };
+  }
+
+  private async resolveConfigFilePath(): Promise<string | null> {
+    if (!this.configFilePath) {
+      return null;
+    }
+
+    try {
+      const resolved = await fs.realpath(this.configFilePath);
+      return typeof resolved === 'string' && resolved.length > 0
+        ? resolved
+        : this.configFilePath;
+    } catch {
+      return this.configFilePath;
+    }
+  }
+
+  private async readConfigData(targetPath: string): Promise<Record<string, any>> {
+    const parsed = JSON.parse(await fs.readFile(targetPath, 'utf-8'));
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('Configuration root must be an object');
+    }
+    return parsed as Record<string, any>;
+  }
+
+  private extractLearnedPatterns(configData: Record<string, any>): LearnedPattern[] {
+    const learnedPatterns = configData.errorPatterns?.learnedPatterns;
+    return Array.isArray(learnedPatterns)
+      ? learnedPatterns.filter(isValidLearnedPattern)
+      : [];
+  }
+
+  private async writeConfigData(
+    targetPath: string,
+    configData: Record<string, any>,
+    patterns: LearnedPattern[],
+  ): Promise<void> {
+    if (configData.errorPatterns !== undefined &&
+        (!configData.errorPatterns || typeof configData.errorPatterns !== 'object' ||
+         Array.isArray(configData.errorPatterns))) {
+      throw new Error('errorPatterns must be an object');
+    }
+    configData.errorPatterns ??= {};
+    configData.errorPatterns.learnedPatterns = patterns;
+
+    const tempPath = join(
+      dirname(targetPath),
+      `.${basename(targetPath)}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`,
+    );
+    try {
+      await fs.writeFile(
+        tempPath,
+        JSON.stringify(configData, null, 2),
+        { encoding: 'utf-8', mode: 0o600 },
+      );
+      await fs.rename(tempPath, targetPath);
+    } catch (error) {
+      try {
+        await fs.unlink(tempPath);
+      } catch {
+        // The temporary file may not have been created.
+      }
+      throw error;
+    }
+  }
+
+  private async withConfigLock<T>(targetPath: string, operation: () => Promise<T>): Promise<T> {
+    const lockPath = join(dirname(targetPath), `.${basename(targetPath)}.pattern-learning.lock`);
+    const lock = await this.acquireConfigLock(lockPath);
+    try {
+      return await operation();
+    } finally {
+      try {
+        await lock.handle.close();
+      } finally {
+        try {
+          const currentToken = await fs.readFile(lock.lockPath, 'utf-8');
+          if (currentToken === lock.token) {
+            await fs.unlink(lock.lockPath);
+          }
+        } catch {
+          // A stale-lock cleanup may already have removed it.
+        }
+      }
+    }
+  }
+
+  private async acquireConfigLock(lockPath: string): Promise<ConfigLock> {
+    for (let attempt = 0; attempt < LOCK_MAX_ATTEMPTS; attempt++) {
+      try {
+        const handle = await fs.open(lockPath, 'wx', 0o600);
+        const token = `${process.pid}:${Date.now()}:${Math.random().toString(16).slice(2)}`;
+        try {
+          await handle.writeFile(token, 'utf-8');
+        } catch (error) {
+          await handle.close().catch(() => undefined);
+          await fs.unlink(lockPath).catch(() => undefined);
+          throw error;
+        }
+        return { handle, lockPath, token };
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code !== 'EEXIST') {
+          throw error;
+        }
+
+        try {
+          const staleToken = await fs.readFile(lockPath, 'utf-8');
+          const lockStat = await fs.stat(lockPath);
+          if (Date.now() - lockStat.mtimeMs > LOCK_STALE_MS) {
+            const currentToken = await fs.readFile(lockPath, 'utf-8');
+            if (currentToken === staleToken) {
+              await fs.unlink(lockPath);
+            }
+            continue;
+          }
+        } catch (statError) {
+          if ((statError as NodeJS.ErrnoException).code === 'ENOENT') {
+            continue;
+          }
+        }
+
+        await new Promise(resolve => setTimeout(resolve, LOCK_RETRY_DELAY_MS));
+      }
+    }
+
+    throw new Error(`Timed out waiting for pattern learning lock: ${lockPath}`);
   }
 }

--- a/src/main/ConfigReloader.ts
+++ b/src/main/ConfigReloader.ts
@@ -172,10 +172,6 @@ export class ConfigReloader {
       this.components.errorPatternRegistry.replaceCustomPatterns(customPatterns);
       this.logger.info(`Reloaded ${customPatterns.length} custom error patterns`);
 
-      const learnedPatterns = newConfig.errorPatterns?.learnedPatterns ?? [];
-      this.components.errorPatternRegistry.updateLearnedPatterns(learnedPatterns);
-      this.logger.info(`Reloaded ${learnedPatterns.length} learned patterns`);
-
       const ignorePatterns = newConfig.errorPatterns?.ignorePatterns ?? DEFAULT_ERROR_PATTERNS_CONFIG.ignorePatterns;
       this.components.errorPatternRegistry.registerIgnorePatterns(ignorePatterns);
       this.logger.info(`Reloaded ${ignorePatterns.length} ignore patterns`);
@@ -191,6 +187,10 @@ export class ConfigReloader {
         patternLearningConfig,
         configSource ?? this.configPath ?? undefined,
       );
+
+      const learnedPatterns = newConfig.errorPatterns?.learnedPatterns ?? [];
+      this.components.errorPatternRegistry.updateLearnedPatterns(learnedPatterns);
+      this.logger.info(`Reloaded ${Math.min(learnedPatterns.length, patternLearningConfig.maxLearnedPatterns)} learned patterns`);
     }
 
     // Update the remaining components only after pattern settings have been

--- a/src/metrics/MetricsManager.ts
+++ b/src/metrics/MetricsManager.ts
@@ -62,6 +62,14 @@ export class MetricsManager {
         reorders: 0,
         modelsWithDynamicScores: 0,
       },
+      patternLearning: {
+        totalErrorsProcessed: 0,
+        patternsLearned: 0,
+        patternsRejected: 0,
+        persistenceFailures: 0,
+        averageConfidence: 0,
+        learnedPatternMatches: 0,
+      },
       startedAt: Date.now(),
       generatedAt: Date.now(),
     };
@@ -123,6 +131,14 @@ export class MetricsManager {
         reorders: 0,
         modelsWithDynamicScores: 0,
       },
+      patternLearning: {
+        totalErrorsProcessed: 0,
+        patternsLearned: 0,
+        patternsRejected: 0,
+        persistenceFailures: 0,
+        averageConfidence: 0,
+        learnedPatternMatches: 0,
+      },
       startedAt: Date.now(),
       generatedAt: Date.now(),
     };
@@ -154,6 +170,36 @@ export class MetricsManager {
         lastOccurrence: now,
       });
     }
+  }
+
+  recordPatternErrorProcessed(): void {
+    if (!this.config.enabled) return;
+    this.metrics.patternLearning.totalErrorsProcessed++;
+  }
+
+  recordPatternLearned(confidence: number): void {
+    if (!this.config.enabled) return;
+    const previousCount = this.metrics.patternLearning.patternsLearned;
+    const previousTotal = this.metrics.patternLearning.averageConfidence * previousCount;
+    this.metrics.patternLearning.patternsLearned++;
+    this.metrics.patternLearning.averageConfidence = Number((
+      (previousTotal + confidence) / this.metrics.patternLearning.patternsLearned
+    ).toFixed(4));
+  }
+
+  recordPatternRejected(): void {
+    if (!this.config.enabled) return;
+    this.metrics.patternLearning.patternsRejected++;
+  }
+
+  recordPatternPersistenceFailure(): void {
+    if (!this.config.enabled) return;
+    this.metrics.patternLearning.persistenceFailures++;
+  }
+
+  recordLearnedPatternMatch(): void {
+    if (!this.config.enabled) return;
+    this.metrics.patternLearning.learnedPatternMatches++;
   }
 
   /**
@@ -440,6 +486,7 @@ export class MetricsManager {
         ),
       },
       dynamicPrioritization: metrics.dynamicPrioritization,
+      patternLearning: metrics.patternLearning,
       startedAt: metrics.startedAt,
       generatedAt: metrics.generatedAt,
     };
@@ -574,6 +621,17 @@ export class MetricsManager {
     lines.push(`  Enabled: ${metrics.dynamicPrioritization.enabled ? 'Yes' : 'No'}`);
     lines.push(`  Reorders: ${metrics.dynamicPrioritization.reorders}`);
     lines.push(`  Models with dynamic scores: ${metrics.dynamicPrioritization.modelsWithDynamicScores}`);
+    lines.push("");
+
+    // Pattern Learning
+    lines.push("Pattern Learning:");
+    lines.push("-".repeat(40));
+    lines.push(`  Errors Processed: ${metrics.patternLearning.totalErrorsProcessed}`);
+    lines.push(`  Patterns Learned: ${metrics.patternLearning.patternsLearned}`);
+    lines.push(`  Patterns Rejected: ${metrics.patternLearning.patternsRejected}`);
+    lines.push(`  Persistence Failures: ${metrics.patternLearning.persistenceFailures}`);
+    lines.push(`  Average Confidence: ${metrics.patternLearning.averageConfidence.toFixed(2)}`);
+    lines.push(`  Learned Pattern Matches: ${metrics.patternLearning.learnedPatternMatches}`);
 
     return lines.join("\n");
   }
@@ -700,6 +758,19 @@ export class MetricsManager {
       metrics.dynamicPrioritization.enabled ? 'Yes' : 'No',
       metrics.dynamicPrioritization.reorders,
       metrics.dynamicPrioritization.modelsWithDynamicScores,
+    ].join(","));
+    lines.push("");
+
+    // Pattern Learning CSV
+    lines.push("=== PATTERN_LEARNING ===");
+    lines.push("errors_processed,patterns_learned,patterns_rejected,persistence_failures,average_confidence,learned_pattern_matches");
+    lines.push([
+      metrics.patternLearning.totalErrorsProcessed,
+      metrics.patternLearning.patternsLearned,
+      metrics.patternLearning.patternsRejected,
+      metrics.patternLearning.persistenceFailures,
+      metrics.patternLearning.averageConfidence,
+      metrics.patternLearning.learnedPatternMatches,
     ].join(","));
 
     return lines.join("\n");

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -223,6 +223,35 @@ export interface PatternLearningConfig {
 }
 
 /**
+ * Runtime statistics for automatic pattern learning.
+ */
+export interface PatternLearningStats {
+  totalErrorsProcessed: number;
+  patternsLearned: number;
+  patternsRejected: number;
+  persistenceFailures: number;
+}
+
+/**
+ * Aggregated pattern learning metrics, including confidence and live usage.
+ */
+export interface PatternLearningMetrics extends PatternLearningStats {
+  averageConfidence: number;
+  learnedPatternMatches: number;
+}
+
+/**
+ * Optional metrics sink used by the learner without coupling it to MetricsManager.
+ */
+export interface PatternLearningMetricsSink {
+  recordPatternErrorProcessed(): void;
+  recordPatternLearned(confidence: number): void;
+  recordPatternRejected(): void;
+  recordPatternPersistenceFailure(): void;
+  recordLearnedPatternMatch(): void;
+}
+
+/**
  * Learned pattern with confidence metadata
  */
 export interface LearnedPattern extends ErrorPattern {
@@ -494,6 +523,7 @@ export interface MetricsData {
     byModel: Map<string, CircuitBreakerMetrics>;
   };
   dynamicPrioritization: DynamicPrioritizationMetrics;
+  patternLearning: PatternLearningMetrics;
   startedAt: number;
   generatedAt: number;
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -114,6 +114,26 @@ export function validateConfig(config: Partial<PluginConfig>): PluginConfig {
   const learnedPatterns = Array.isArray(errorPatterns?.learnedPatterns)
     ? errorPatterns.learnedPatterns.filter(isValidLearnedPattern)
     : undefined;
+  const enableLearning = typeof errorPatterns?.enableLearning === 'boolean'
+    ? errorPatterns.enableLearning
+    : DEFAULT_PATTERN_LEARNING_CONFIG.enabled;
+  const autoApproveThreshold = typeof errorPatterns?.autoApproveThreshold === 'number' &&
+    Number.isFinite(errorPatterns.autoApproveThreshold) &&
+    errorPatterns.autoApproveThreshold >= 0 && errorPatterns.autoApproveThreshold <= 1
+    ? errorPatterns.autoApproveThreshold
+    : DEFAULT_PATTERN_LEARNING_CONFIG.autoApproveThreshold;
+  const maxLearnedPatterns = Number.isInteger(errorPatterns?.maxLearnedPatterns) &&
+    (errorPatterns?.maxLearnedPatterns ?? 0) > 0
+    ? errorPatterns!.maxLearnedPatterns
+    : DEFAULT_PATTERN_LEARNING_CONFIG.maxLearnedPatterns;
+  const minErrorFrequency = Number.isInteger(errorPatterns?.minErrorFrequency) &&
+    (errorPatterns?.minErrorFrequency ?? 0) > 0
+    ? errorPatterns!.minErrorFrequency
+    : DEFAULT_PATTERN_LEARNING_CONFIG.minErrorFrequency;
+  const learningWindowMs = typeof errorPatterns?.learningWindowMs === 'number' &&
+    Number.isFinite(errorPatterns.learningWindowMs) && errorPatterns.learningWindowMs > 0
+    ? errorPatterns.learningWindowMs
+    : DEFAULT_PATTERN_LEARNING_CONFIG.learningWindowMs;
 
   return {
     ...DEFAULT_CONFIG,
@@ -164,11 +184,11 @@ export function validateConfig(config: Partial<PluginConfig>): PluginConfig {
       custom: customPatterns,
       ignorePatterns,
       learnedPatterns,
-      enableLearning: errorPatterns.enableLearning ?? DEFAULT_PATTERN_LEARNING_CONFIG.enabled,
-      autoApproveThreshold: errorPatterns.autoApproveThreshold ?? DEFAULT_PATTERN_LEARNING_CONFIG.autoApproveThreshold,
-      maxLearnedPatterns: errorPatterns.maxLearnedPatterns ?? DEFAULT_PATTERN_LEARNING_CONFIG.maxLearnedPatterns,
-      minErrorFrequency: errorPatterns.minErrorFrequency ?? DEFAULT_PATTERN_LEARNING_CONFIG.minErrorFrequency,
-      learningWindowMs: errorPatterns.learningWindowMs ?? DEFAULT_PATTERN_LEARNING_CONFIG.learningWindowMs,
+      enableLearning,
+      autoApproveThreshold,
+      maxLearnedPatterns,
+      minErrorFrequency,
+      learningWindowMs,
     } : DEFAULT_ERROR_PATTERNS_CONFIG,
   };
 }


### PR DESCRIPTION
## Summary

- complete automatic rate-limit pattern learning for unknown provider errors
- persist learned patterns atomically and refresh the live registry immediately
- isolate learned patterns by provider and enforce confidence, frequency, window, and capacity limits
- expose learning diagnostics and metrics, with startup and hot-reload hydration
- validate malformed pattern entries safely in strict and non-strict modes
- bump the package version to `1.70.9`

## Safety and reliability

- rejects server errors and quota-related text without explicit depletion or rate-limit semantics
- preserves symlinked config files and watches their canonical targets across atomic replacement
- serializes same-process and cross-process writes with lock-protected read-modify-write
- bounds candidate tracking even while persistence is pending
- keeps provider-scoped learned patterns inactive without a reliable provider hint
- keeps learned patterns with confidence `<= 0.7` available for review but inactive for detection

## Validation

- `npm test` (699 passed, 11 skipped; 24 files)
- `npm run typecheck`
- `npm run build`
- `npm pack --dry-run --json` (`1.70.9`, 57 files)
- `npm audit --omit=dev --json` (0 vulnerabilities)
- `git diff --check`
- real SDK E2E with `@opencode-ai/sdk@1.18.16`
  - immediate learned-pattern fallback
  - provider isolation
  - config watcher survives atomic replacement
  - symlink remains intact
- separate-process persistence E2E (2 writers, 2 saved patterns, 0 lost updates)
- independent Sol review: APPROVED, no findings

Fixes #18
