### PR TITLE
docs: fix OpenCode plugin installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,23 +34,15 @@ Add the plugin to your `opencode.json`:
 
 ```json
 {
-  "plugins": ["@azumag/opencode-rate-limit-fallback"]
+  "plugin": ["@azumag/opencode-rate-limit-fallback"]
 }
 ```
 
 OpenCode will automatically install the plugin on startup.
 
-### Manual Installation (Alternative)
-
-Copy `index.ts` to your OpenCode plugins directory:
-
-```bash
-mkdir -p ~/.config/opencode/plugins
-curl -o ~/.config/opencode/plugins/rate-limit-fallback.ts \
-  https://raw.githubusercontent.com/azumag/opencode-rate-limit-fallback/main/index.ts
-```
-
-Restart OpenCode to load the plugin.
+This release is tested with OpenCode `1.18.16`. Older OpenCode releases may
+fail to install the matching plugin SDK dependencies; upgrade OpenCode before
+installing this plugin.
 
 ## Configuration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azumag/opencode-rate-limit-fallback",
-  "version": "1.70.9",
+  "version": "1.70.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azumag/opencode-rate-limit-fallback",
-      "version": "1.70.9",
+      "version": "1.70.10",
       "license": "MIT",
       "dependencies": {
         "@opencode-ai/plugin": "1.18.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azumag/opencode-rate-limit-fallback",
-  "version": "1.70.9",
+  "version": "1.70.10",
   "description": "OpenCode plugin that automatically switches to fallback models when rate limited",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- use the stable OpenCode `plugin` config key
- remove the broken single-file manual install instructions
- document the OpenCode 1.18.16 compatibility baseline
- bump the package version to 1.70.10

## Validation
- `npm test` (699 passed, 11 skipped)
- `npm run typecheck`
- `npm run build`
- `npm pack --dry-run --json`
- clean published-package SDK E2E
- OpenCode 1.18.16 cold install and `/config` smoke test
- independent Sol review: approved