### PR TITLE
fix: use valid npm tag for v2 releases

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -81,7 +81,7 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           MAJOR=${VERSION%%.*}
           if [ "$MAJOR" -ge 2 ]; then
-            npm publish --access public --ignore-scripts --tag v2
+            npm publish --access public --ignore-scripts --tag opencode-v2
           else
             npm publish --access public --ignore-scripts
           fi

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ OpenCode v2 / Web uses the `plugins` key:
 
 ```json
 {
-  "plugins": ["@azumag/opencode-rate-limit-fallback@2.0.0"]
+  "plugins": ["@azumag/opencode-rate-limit-fallback@2.0.1"]
 }
 ```
 
@@ -46,7 +46,7 @@ OpenCode v1 must stay on the latest 1.x release:
 }
 ```
 
-Version 2 is published under the `v2` npm tag so unpinned OpenCode v1
+Version 2 is published under the `opencode-v2` npm tag so unpinned OpenCode v1
 installations do not receive the incompatible v2 entry point.
 
 The v2 entry point currently implements `fallbackMode: "wait"`. Model-switching

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azumag/opencode-rate-limit-fallback",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azumag/opencode-rate-limit-fallback",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "devDependencies": {
         "@opencode-ai/plugin": "1.18.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azumag/opencode-rate-limit-fallback",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "OpenCode plugin that automatically switches to fallback models when rate limited",
   "main": "dist/v2.js",
   "types": "dist/v2.d.ts",


### PR DESCRIPTION
## Summary
- replace the invalid npm dist-tag `v2` with `opencode-v2`
- bump the unpublished v2 package to 2.0.1 so the corrected publish workflow runs after merge
- update installation documentation

## Cause
The first post-merge publish correctly avoided `latest`, but npm rejected `v2` because it is a valid SemVer range. No 2.x package was published.

## Validation
- `npm run typecheck`
- `npm test -- __tests__/v2.test.ts`